### PR TITLE
Remove package functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,41 @@
 # 🍕 `github.com/elliotchance/pie` [![GoDoc](https://godoc.org/github.com/elliotchance/pie?status.svg)](https://godoc.org/github.com/elliotchance/pie)
 
 **Enjoy a slice!** `pie` is a utility library for dealing with slices that
-focuses on type safety and performance.
+focuses on type safety, performance and immutability.
 
-It can be used with the Go-style package functions:
+- [Quick Start](#quick-start)
+- [Functions](#functions)
+  * [Slices](#slices)
+  * [Conditional](#conditional)
+  * [Transforms](#transforms)
+- [FAQ](#faq)
+  * [How do I use it?](#how-do-i-use-it-)
+  * [Why do we need another library for this?](#why-do-we-need-another-library-for-this-)
+  * [What are the goals of `pie`?](#what-are-the-goals-of--pie--)
+  * [Can I contribute?](#can-i-contribute-)
+  * [Why is the emoji a slice of pizza instead of a pie?](#why-is-the-emoji-a-slice-of-pizza-instead-of-a-pie-)
+  * [Why does it not have package level functions?](#why-does-it-not-have-package-level-functions-)
+
+# Quick Start
+
+Pie has three basic slice types:
+
+- `Strings` is an alias for `[]string`.
+- `Ints` is an alias for `[]int`.
+- `Float64s` is an alias for `[]float64`.
+
+Since these are aliases they can be used interchangeably:
 
 ```go
 names := []string{"Bob", "Sally", "John", "Jane"}
-shortNames := pie.StringsOnly(names, func(s string) bool {
+var shortNames []string = pie.Strings(names).Only(func(s string) bool {
 	return len(s) <= 3
 })
 
-// []string{"Bob"}
+// shortNames = []string{"Bob"}
 ```
 
-Or, they can be chained for more complex operations:
+Or, more complex operations can be chained:
 
 ```go
 pie.Strings{"Bob", "Sally", "John", "Jane"}.
@@ -31,20 +52,20 @@ pie.Strings{"Bob", "Sally", "John", "Jane"}.
 
 | Function     | Description | Strings | Ints  | Float64s |       |
 | ------------ | ----------- | :-----: | :---: | :------: | :---: |
-| `Average`    | The average (mean) value, or a zeroed value. | | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsAverage) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sAverage)| O(n) |
-| `Contains`   | Check if the value exists in the slice. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsContains) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsContains) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sContains)| O(n) |
-| `First`      | The first element, or a zeroed value. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsFirst) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsFirst) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sFirst)| O(1) |
-| `FirstOr`    | The first element, or a default value. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsFirstOr) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsFirstOr) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sFirstOr)| O(1) |
-| `JSONString` | The JSON encoded string. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsJSONString) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsJSONString) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sJSONString)| O(1) |
-| `Last`       | The last element, or a zeroed value. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsLast) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsLast) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sLast)| O(1) |
-| `LastOr`     | The last element, or a default value. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsLastOr) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsLastOr) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sLastOr)| O(1) |
+| `Average`    | The average (mean) value, or a zeroed value. | | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Average) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Average)| O(n) |
+| `Contains`   | Check if the value exists in the slice. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.Contains) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Contains) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Contains)| O(n) |
+| `First`      | The first element, or a zeroed value. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.First) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.First) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.First)| O(1) |
+| `FirstOr`    | The first element, or a default value. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.FirstOr) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.FirstOr) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.FirstOr)| O(1) |
+| `JSONString` | The JSON encoded string. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.JSONString) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.JSONString) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.JSONString)| O(n) |
+| `Last`       | The last element, or a zeroed value. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.Last) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Last) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Last)| O(1) |
+| `LastOr`     | The last element, or a default value. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.LastOr) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.LastOr) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.LastOr)| O(1) |
 | `Len`        | Number of elements. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.Len) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Len) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Len) | O(1) |
-| `Max`        | The maximum value, or a zeroes value. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsMax) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsMax) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sMax)| O(n) |
-| `Min`        | The minimum value, or a zeroed value. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsMin) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsMin) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sMin)| O(n) |
-| `Only`       | A new slice containing only the elements that returned true from the condition. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsOnly) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsOnly) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sOnly)| O(n) |
-| `Sum`        | Sum (total) of all elements. | | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsSum) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sSum)| O(n) |
-| `Transform`  | A new slice where each element has been transformed. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsTransform) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsTransform) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sTransform)| O(n) |
-| `Without`    | A new slice containing only the elements that returned false from the condition. | [Yes](https://godoc.org/github.com/elliotchance/pie#StringsWithout) | [Yes](https://godoc.org/github.com/elliotchance/pie#IntsWithout) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64sWithout)| O(n) |
+| `Max`        | The maximum value, or a zeroes value. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.Max) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Max) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Max)| O(n) |
+| `Min`        | The minimum value, or a zeroed value. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.Min) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Min) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Min)| O(n) |
+| `Only`       | A new slice containing only the elements that returned true from the condition. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.Only) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Only) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Only)| O(n) |
+| `Sum`        | Sum (total) of all elements. | | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Sum) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Sum)| O(n) |
+| `Transform`  | A new slice where each element has been transformed. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.Transform) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Transform) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Transform)| O(n) |
+| `Without`    | A new slice containing only the elements that returned false from the condition. | [Yes](https://godoc.org/github.com/elliotchance/pie#Strings.Without) | [Yes](https://godoc.org/github.com/elliotchance/pie#Ints.Without) | [Yes](https://godoc.org/github.com/elliotchance/pie#Float64s.Without)| O(n) |
 
 ## Conditional
 
@@ -131,3 +152,15 @@ Absolutely. Pull requests are always welcome. Your PR must include:
 ## Why is the emoji a slice of pizza instead of a pie?
 
 I wanted to pick a name for the project that was short and had an associated emoji. I liked pie, but then I found out that the pie emoji is not fully supported everywhere. I didn't want to change the name of the project to cake, but pizza pie still made sense. I'm not sure if I will change it back to a pie later.
+
+## Why does it not have package level functions?
+
+It's temping to add package level functions, like `pie.StringsOnly(ss, fn)` as a
+shortcut for `pie.Strings(ss).Only(fn)`. In fact older versions did actually
+have these. I removed them because:
+
+1. The `pie` types are aliases so there is no special operation to use
+`[]string` and `pie.Strings` interchangeably.
+
+2. It created a huge amount of duplicate code that also created lots of extra
+tests and more complicated documentation.

--- a/float64s.go
+++ b/float64s.go
@@ -15,8 +15,8 @@ import "encoding/json"
 //
 type Float64s []float64
 
-// Float64sContains returns true if the float64 exists in the slice.
-func Float64sContains(ss []float64, lookingFor float64) bool {
+// Contains returns true if the float64 exists in the slice.
+func (ss Float64s) Contains(lookingFor float64) bool {
 	for _, s := range ss {
 		if s == lookingFor {
 			return true
@@ -26,16 +26,11 @@ func Float64sContains(ss []float64, lookingFor float64) bool {
 	return false
 }
 
-// Contains is the chained version of Float64sContains.
-func (ss Float64s) Contains(lookingFor float64) bool {
-	return Float64sContains(ss, lookingFor)
-}
-
-// Float64sOnly will return a new slice containing only the elements that return
+// Only will return a new slice containing only the elements that return
 // true from the condition. The returned slice may contain zero elements (nil).
 //
 // Float64sWithout works in the opposite way as Float64sOnly.
-func Float64sOnly(ss []float64, condition Float64ConditionFunc) (ss2 []float64) {
+func (ss Float64s) Only(condition Float64ConditionFunc) (ss2 Float64s) {
 	for _, s := range ss {
 		if condition(s) {
 			ss2 = append(ss2, s)
@@ -45,15 +40,10 @@ func Float64sOnly(ss []float64, condition Float64ConditionFunc) (ss2 []float64) 
 	return
 }
 
-// Only is the chained version of Float64sOnly.
-func (ss Float64s) Only(condition Float64ConditionFunc) (ss2 Float64s) {
-	return Float64sOnly(ss, condition)
-}
-
-// Float64sWithout works the same as Float64sOnly, with a negated condition. That is, it
+// Without works the same as Float64sOnly, with a negated condition. That is, it
 // will return a new slice only containing the elements that returned false from
 // the condition. The returned slice may contain zero elements (nil).
-func Float64sWithout(ss []float64, condition Float64ConditionFunc) (ss2 []float64) {
+func (ss Float64s) Without(condition Float64ConditionFunc) (ss2 Float64s) {
 	for _, s := range ss {
 		if !condition(s) {
 			ss2 = append(ss2, s)
@@ -63,15 +53,9 @@ func Float64sWithout(ss []float64, condition Float64ConditionFunc) (ss2 []float6
 	return
 }
 
-// Without is the chained version of Float64sWithout.
-func (ss Float64s) Without(condition Float64ConditionFunc) (ss2 Float64s) {
-	return Float64sWithout(ss, condition)
-}
-
-// Float64sTransform will return a new slice where each element has been
-// transformed. The number of element returned will always be the same as the
-// input.
-func Float64sTransform(ss []float64, fn Float64TransformFunc) (ss2 []float64) {
+// Transform will return a new slice where each element has been transformed.
+// The number of element returned will always be the same as the input.
+func (ss Float64s) Transform(fn Float64TransformFunc) (ss2 Float64s) {
 	if ss == nil {
 		return nil
 	}
@@ -84,14 +68,9 @@ func Float64sTransform(ss []float64, fn Float64TransformFunc) (ss2 []float64) {
 	return
 }
 
-// Transform is the chained version of Float64sTransform.
-func (ss Float64s) Transform(fn Float64TransformFunc) (ss2 Float64s) {
-	return Float64sTransform(ss, fn)
-}
-
-// Float64sFirstOr returns the first element or a default value if there are no
+// FirstOr returns the first element or a default value if there are no
 // elements.
-func Float64sFirstOr(ss []float64, defaultValue float64) float64 {
+func (ss Float64s) FirstOr(defaultValue float64) float64 {
 	if len(ss) == 0 {
 		return defaultValue
 	}
@@ -99,14 +78,8 @@ func Float64sFirstOr(ss []float64, defaultValue float64) float64 {
 	return ss[0]
 }
 
-// FirstOr is the chained version of Float64sFirstOr.
-func (ss Float64s) FirstOr(defaultValue float64) float64 {
-	return Float64sFirstOr(ss, defaultValue)
-}
-
-// Float64sLastOr returns the last element or a default value if there are no
-// elements.
-func Float64sLastOr(ss []float64, defaultValue float64) float64 {
+// LastOr returns the last element or a default value if there are no elements.
+func (ss Float64s) LastOr(defaultValue float64) float64 {
 	if len(ss) == 0 {
 		return defaultValue
 	}
@@ -114,33 +87,18 @@ func Float64sLastOr(ss []float64, defaultValue float64) float64 {
 	return ss[len(ss)-1]
 }
 
-// LastOr is the chained version of Float64sLastOr.
-func (ss Float64s) LastOr(defaultValue float64) float64 {
-	return Float64sLastOr(ss, defaultValue)
-}
-
-// Float64sFirst returns the first element, or zero. Also see Float64sFirstOr.
-func Float64sFirst(ss []float64) float64 {
-	return Float64sFirstOr(ss, 0)
-}
-
-// First is the chained version of Float64sFirst.
+// First returns the first element, or zero. Also see FirstOr().
 func (ss Float64s) First() float64 {
-	return Float64sFirst(ss)
+	return ss.FirstOr(0)
 }
 
-// Float64sLast returns the last element, or zero. Also see Float64sLastOr.
-func Float64sLast(ss []float64) float64 {
-	return Float64sLastOr(ss, 0)
-}
-
-// Last is the chained version of Float64sLast.
+// Last returns the last element, or zero. Also see LastOr().
 func (ss Float64s) Last() float64 {
-	return Float64sLast(ss)
+	return ss.LastOr(0)
 }
 
-// Float64sSum is the sum of all of the elements.
-func Float64sSum(ss []float64) (sum float64) {
+// Sum is the sum of all of the elements.
+func (ss Float64s) Sum() (sum float64) {
 	for _, s := range ss {
 		sum += s
 	}
@@ -148,33 +106,23 @@ func Float64sSum(ss []float64) (sum float64) {
 	return
 }
 
-// Sum is the chained version of Float64sSum.
-func (ss Float64s) Sum() float64 {
-	return Float64sSum(ss)
-}
-
 // Len returns the number of elements.
 func (ss Float64s) Len() int {
 	return len(ss)
 }
 
-// Float64sAverage is the average of all of the elements, or zero if there are no
+// Average is the average of all of the elements, or zero if there are no
 // elements.
-func Float64sAverage(ss []float64) float64 {
+func (ss Float64s) Average() float64 {
 	if l := float64(len(ss)); l > 0 {
-		return Float64sSum(ss) / l
+		return ss.Sum() / l
 	}
 
 	return 0
 }
 
-// Average is the chained version of Float64sAverage.
-func (ss Float64s) Average() float64 {
-	return Float64sAverage(ss)
-}
-
-// Float64sMin is the minimum value, or zero.
-func Float64sMin(ss []float64) (min float64) {
+// Min is the minimum value, or zero.
+func (ss Float64s) Min() (min float64) {
 	if len(ss) == 0 {
 		return
 	}
@@ -189,13 +137,8 @@ func Float64sMin(ss []float64) (min float64) {
 	return
 }
 
-// Min is the chained version of Float64sMin.
-func (ss Float64s) Min() float64 {
-	return Float64sMin(ss)
-}
-
-// Float64sMax is the maximum value, or zero.
-func Float64sMax(ss []float64) (max float64) {
+// Max is the maximum value, or zero.
+func (ss Float64s) Max() (max float64) {
 	if len(ss) == 0 {
 		return
 	}
@@ -208,11 +151,6 @@ func Float64sMax(ss []float64) (max float64) {
 	}
 
 	return
-}
-
-// Max is the chained version of Float64sMax.
-func (ss Float64s) Max() float64 {
-	return Float64sMax(ss)
 }
 
 // JSONString returns the JSON encoded array as a string.

--- a/float64s_test.go
+++ b/float64s_test.go
@@ -30,15 +30,6 @@ func TestFloat64s_Contains(t *testing.T) {
 	}
 }
 
-func TestFloat64sContains(t *testing.T) {
-	for _, test := range float64sContainsTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.expected, pie.Float64sContains(test.ss, test.contains))
-		})
-	}
-}
-
 var float64sOnlyAndWithoutTests = []struct {
 	ss                pie.Float64s
 	condition         func(float64) bool
@@ -75,15 +66,6 @@ func TestFloat64s_Only(t *testing.T) {
 	}
 }
 
-func TestFloat64sOnly(t *testing.T) {
-	for _, test := range float64sOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, []float64(test.expectedOnly), pie.Float64sOnly(test.ss, test.condition))
-		})
-	}
-}
-
 func TestFloat64s_Without(t *testing.T) {
 	for _, test := range float64sOnlyAndWithoutTests {
 		t.Run("", func(t *testing.T) {
@@ -93,29 +75,11 @@ func TestFloat64s_Without(t *testing.T) {
 	}
 }
 
-func TestFloat64sWithout(t *testing.T) {
-	for _, test := range float64sOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, []float64(test.expectedWithout), pie.Float64sWithout(test.ss, test.condition))
-		})
-	}
-}
-
 func TestFloat64s_Transform(t *testing.T) {
 	for _, test := range float64sOnlyAndWithoutTests {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableFloat64s(t, &test.ss)()
 			assert.Equal(t, test.expectedTransform, test.ss.Transform(pie.AddFloat64(5.2)))
-		})
-	}
-}
-
-func TestFloat64sTransform(t *testing.T) {
-	for _, test := range float64sOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, []float64(test.expectedTransform), pie.Float64sTransform(test.ss, pie.AddFloat64(5.2)))
 		})
 	}
 }
@@ -164,29 +128,11 @@ func TestFloat64s_FirstOr(t *testing.T) {
 	}
 }
 
-func TestFloat64sFirstOr(t *testing.T) {
-	for _, test := range float64sFirstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.firstOr, pie.Float64sFirstOr(test.ss, 102))
-		})
-	}
-}
-
 func TestFloat64s_LastOr(t *testing.T) {
 	for _, test := range float64sFirstAndLastTests {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableFloat64s(t, &test.ss)()
 			assert.Equal(t, test.lastOr, test.ss.LastOr(202))
-		})
-	}
-}
-
-func TestFloat64sLastOr(t *testing.T) {
-	for _, test := range float64sFirstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.lastOr, pie.Float64sLastOr(test.ss, 202))
 		})
 	}
 }
@@ -200,29 +146,11 @@ func TestFloat64s_First(t *testing.T) {
 	}
 }
 
-func TestFloat64sFirst(t *testing.T) {
-	for _, test := range float64sFirstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.first, pie.Float64sFirst(test.ss))
-		})
-	}
-}
-
 func TestFloat64s_Last(t *testing.T) {
 	for _, test := range float64sFirstAndLastTests {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableFloat64s(t, &test.ss)()
 			assert.Equal(t, test.last, test.ss.Last())
-		})
-	}
-}
-
-func TestFloat64sLast(t *testing.T) {
-	for _, test := range float64sFirstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.last, pie.Float64sLast(test.ss))
 		})
 	}
 }
@@ -267,15 +195,6 @@ var float64sStatsTests = []struct {
 	},
 }
 
-func TestFloat64sMin(t *testing.T) {
-	for _, test := range float64sStatsTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.min, pie.Float64sMin(test.ss))
-		})
-	}
-}
-
 func TestFloat64s_Min(t *testing.T) {
 	for _, test := range float64sStatsTests {
 		t.Run("", func(t *testing.T) {
@@ -285,29 +204,11 @@ func TestFloat64s_Min(t *testing.T) {
 	}
 }
 
-func TestFloat64sMax(t *testing.T) {
-	for _, test := range float64sStatsTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.max, pie.Float64sMax(test.ss))
-		})
-	}
-}
-
 func TestFloat64s_Max(t *testing.T) {
 	for _, test := range float64sStatsTests {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableFloat64s(t, &test.ss)()
 			assert.Equal(t, test.max, pie.Float64s(test.ss).Max())
-		})
-	}
-}
-
-func TestFloat64sSum(t *testing.T) {
-	for _, test := range float64sStatsTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.sum, pie.Float64sSum(test.ss))
 		})
 	}
 }
@@ -326,15 +227,6 @@ func TestFloat64s_Len(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableFloat64s(t, &test.ss)()
 			assert.Equal(t, test.len, pie.Float64s(test.ss).Len())
-		})
-	}
-}
-
-func TestFloat64sAverage(t *testing.T) {
-	for _, test := range float64sStatsTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableFloat64s(t, &test.ss)()
-			assert.Equal(t, test.average, pie.Float64sAverage(test.ss))
 		})
 	}
 }

--- a/ints.go
+++ b/ints.go
@@ -15,8 +15,8 @@ import "encoding/json"
 //
 type Ints []int
 
-// IntsContains returns true if the int exists in the slice.
-func IntsContains(ss []int, lookingFor int) bool {
+// Contains returns true if the int exists in the slice.
+func (ss Ints) Contains(lookingFor int) bool {
 	for _, s := range ss {
 		if s == lookingFor {
 			return true
@@ -26,16 +26,11 @@ func IntsContains(ss []int, lookingFor int) bool {
 	return false
 }
 
-// Contains is the chained version of IntsContains.
-func (ss Ints) Contains(lookingFor int) bool {
-	return IntsContains(ss, lookingFor)
-}
-
-// IntsOnly will return a new slice containing only the elements that return
+// Only will return a new slice containing only the elements that return
 // true from the condition. The returned slice may contain zero elements (nil).
 //
 // IntsWithout works in the opposite way as IntsOnly.
-func IntsOnly(ss []int, condition IntConditionFunc) (ss2 []int) {
+func (ss Ints) Only(condition IntConditionFunc) (ss2 Ints) {
 	for _, s := range ss {
 		if condition(s) {
 			ss2 = append(ss2, s)
@@ -45,15 +40,10 @@ func IntsOnly(ss []int, condition IntConditionFunc) (ss2 []int) {
 	return
 }
 
-// Only is the chained version of IntsOnly.
-func (ss Ints) Only(condition IntConditionFunc) (ss2 Ints) {
-	return IntsOnly(ss, condition)
-}
-
-// IntsWithout works the same as IntsOnly, with a negated condition. That is, it
+// Without works the same as IntsOnly, with a negated condition. That is, it
 // will return a new slice only containing the elements that returned false from
 // the condition. The returned slice may contain zero elements (nil).
-func IntsWithout(ss []int, condition IntConditionFunc) (ss2 []int) {
+func (ss Ints) Without(condition IntConditionFunc) (ss2 Ints) {
 	for _, s := range ss {
 		if !condition(s) {
 			ss2 = append(ss2, s)
@@ -63,15 +53,9 @@ func IntsWithout(ss []int, condition IntConditionFunc) (ss2 []int) {
 	return
 }
 
-// Without is the chained version of IntsWithout.
-func (ss Ints) Without(condition IntConditionFunc) (ss2 Ints) {
-	return IntsWithout(ss, condition)
-}
-
-// IntsTransform will return a new slice where each element has been
-// transformed. The number of element returned will always be the same as the
-// input.
-func IntsTransform(ss []int, fn IntTransformFunc) (ss2 []int) {
+// Transform will return a new slice where each element has been transformed.
+// The number of element returned will always be the same as the input.
+func (ss Ints) Transform(fn IntTransformFunc) (ss2 Ints) {
 	if ss == nil {
 		return nil
 	}
@@ -84,14 +68,9 @@ func IntsTransform(ss []int, fn IntTransformFunc) (ss2 []int) {
 	return
 }
 
-// Transform is the chained version of IntsTransform.
-func (ss Ints) Transform(fn IntTransformFunc) (ss2 Ints) {
-	return IntsTransform(ss, fn)
-}
-
-// IntsFirstOr returns the first element or a default value if there are no
+// FirstOr returns the first element or a default value if there are no
 // elements.
-func IntsFirstOr(ss []int, defaultValue int) int {
+func (ss Ints) FirstOr(defaultValue int) int {
 	if len(ss) == 0 {
 		return defaultValue
 	}
@@ -99,14 +78,8 @@ func IntsFirstOr(ss []int, defaultValue int) int {
 	return ss[0]
 }
 
-// FirstOr is the chained version of IntsFirstOr.
-func (ss Ints) FirstOr(defaultValue int) int {
-	return IntsFirstOr(ss, defaultValue)
-}
-
-// IntsLastOr returns the last element or a default value if there are no
-// elements.
-func IntsLastOr(ss []int, defaultValue int) int {
+// LastOr returns the last element or a default value if there are no elements.
+func (ss Ints) LastOr(defaultValue int) int {
 	if len(ss) == 0 {
 		return defaultValue
 	}
@@ -114,33 +87,18 @@ func IntsLastOr(ss []int, defaultValue int) int {
 	return ss[len(ss)-1]
 }
 
-// LastOr is the chained version of IntsLastOr.
-func (ss Ints) LastOr(defaultValue int) int {
-	return IntsLastOr(ss, defaultValue)
-}
-
-// IntsFirst returns the first element, or zero. Also see IntsFirstOr.
-func IntsFirst(ss []int) int {
-	return IntsFirstOr(ss, 0)
-}
-
-// First is the chained version of IntsFirst.
+// First returns the first element, or zero. Also see FirstOr().
 func (ss Ints) First() int {
-	return IntsFirst(ss)
+	return ss.FirstOr(0)
 }
 
-// IntsLast returns the last element, or zero. Also see IntsLastOr.
-func IntsLast(ss []int) int {
-	return IntsLastOr(ss, 0)
-}
-
-// Last is the chained version of IntsLast.
+// Last returns the last element, or zero. Also see LastOr().
 func (ss Ints) Last() int {
-	return IntsLast(ss)
+	return ss.LastOr(0)
 }
 
-// IntsSum is the sum of all of the elements.
-func IntsSum(ss []int) (sum int) {
+// Sum is the sum of all of the elements.
+func (ss Ints) Sum() (sum int) {
 	for _, s := range ss {
 		sum += s
 	}
@@ -148,33 +106,23 @@ func IntsSum(ss []int) (sum int) {
 	return
 }
 
-// Sum is the chained version of IntsSum.
-func (ss Ints) Sum() int {
-	return IntsSum(ss)
-}
-
 // Len returns the number of elements.
 func (ss Ints) Len() int {
 	return len(ss)
 }
 
-// IntsAverage is the average of all of the elements, or zero if there are no
+// Average is the average of all of the elements, or zero if there are no
 // elements.
-func IntsAverage(ss []int) float64 {
+func (ss Ints) Average() float64 {
 	if l := float64(len(ss)); l > 0 {
-		return float64(IntsSum(ss)) / l
+		return float64(ss.Sum()) / l
 	}
 
 	return 0
 }
 
-// Average is the chained version of IntsAverage.
-func (ss Ints) Average() float64 {
-	return IntsAverage(ss)
-}
-
-// IntsMin is the minimum value, or zero.
-func IntsMin(ss []int) (min int) {
+// Min is the minimum value, or zero.
+func (ss Ints) Min() (min int) {
 	if len(ss) == 0 {
 		return
 	}
@@ -189,13 +137,8 @@ func IntsMin(ss []int) (min int) {
 	return
 }
 
-// Min is the chained version of IntsMin.
-func (ss Ints) Min() int {
-	return IntsMin(ss)
-}
-
-// IntsMax is the maximum value, or zero.
-func IntsMax(ss []int) (max int) {
+// Max is the maximum value, or zero.
+func (ss Ints) Max() (max int) {
 	if len(ss) == 0 {
 		return
 	}
@@ -208,11 +151,6 @@ func IntsMax(ss []int) (max int) {
 	}
 
 	return
-}
-
-// Max is the chained version of IntsMax.
-func (ss Ints) Max() int {
-	return IntsMax(ss)
 }
 
 // JSONString returns the JSON encoded array as a string.

--- a/ints_test.go
+++ b/ints_test.go
@@ -29,14 +29,6 @@ func TestInts_Contains(t *testing.T) {
 	}
 }
 
-func TestIntsContains(t *testing.T) {
-	for _, test := range intsContainsTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.expected, pie.IntsContains(test.ss, test.contains))
-		})
-	}
-}
-
 var intsOnlyAndWithoutTests = []struct {
 	ss                pie.Ints
 	condition         func(int) bool
@@ -72,14 +64,6 @@ func TestInts_Only(t *testing.T) {
 	}
 }
 
-func TestIntsOnly(t *testing.T) {
-	for _, test := range intsOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, []int(test.expectedOnly), pie.IntsOnly(test.ss, test.condition))
-		})
-	}
-}
-
 func TestInts_Without(t *testing.T) {
 	for _, test := range intsOnlyAndWithoutTests {
 		t.Run("", func(t *testing.T) {
@@ -88,26 +72,10 @@ func TestInts_Without(t *testing.T) {
 	}
 }
 
-func TestIntsWithout(t *testing.T) {
-	for _, test := range intsOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, []int(test.expectedWithout), pie.IntsWithout(test.ss, test.condition))
-		})
-	}
-}
-
 func TestInts_Transform(t *testing.T) {
 	for _, test := range intsOnlyAndWithoutTests {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, test.expectedTransform, test.ss.Transform(pie.AddInt(5)))
-		})
-	}
-}
-
-func TestIntsTransform(t *testing.T) {
-	for _, test := range intsOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, []int(test.expectedTransform), pie.IntsTransform(test.ss, pie.AddInt(5)))
 		})
 	}
 }
@@ -155,26 +123,10 @@ func TestInts_FirstOr(t *testing.T) {
 	}
 }
 
-func TestIntsFirstOr(t *testing.T) {
-	for _, test := range intsFirstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.firstOr, pie.IntsFirstOr(test.ss, 102))
-		})
-	}
-}
-
 func TestInts_LastOr(t *testing.T) {
 	for _, test := range intsFirstAndLastTests {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, test.lastOr, test.ss.LastOr(202))
-		})
-	}
-}
-
-func TestIntsLastOr(t *testing.T) {
-	for _, test := range intsFirstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.lastOr, pie.IntsLastOr(test.ss, 202))
 		})
 	}
 }
@@ -187,26 +139,10 @@ func TestInts_First(t *testing.T) {
 	}
 }
 
-func TestIntsFirst(t *testing.T) {
-	for _, test := range intsFirstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.first, pie.IntsFirst(test.ss))
-		})
-	}
-}
-
 func TestInts_Last(t *testing.T) {
 	for _, test := range intsFirstAndLastTests {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, test.last, test.ss.Last())
-		})
-	}
-}
-
-func TestIntsLast(t *testing.T) {
-	for _, test := range intsFirstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.last, pie.IntsLast(test.ss))
 		})
 	}
 }
@@ -250,14 +186,6 @@ var intsStatsTests = []struct {
 	},
 }
 
-func TestIntsMin(t *testing.T) {
-	for _, test := range intsStatsTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.min, pie.IntsMin(test.ss))
-		})
-	}
-}
-
 func TestInts_Min(t *testing.T) {
 	for _, test := range intsStatsTests {
 		t.Run("", func(t *testing.T) {
@@ -266,26 +194,10 @@ func TestInts_Min(t *testing.T) {
 	}
 }
 
-func TestIntsMax(t *testing.T) {
-	for _, test := range intsStatsTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.max, pie.IntsMax(test.ss))
-		})
-	}
-}
-
 func TestInts_Max(t *testing.T) {
 	for _, test := range intsStatsTests {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, test.max, pie.Ints(test.ss).Max())
-		})
-	}
-}
-
-func TestIntsSum(t *testing.T) {
-	for _, test := range intsStatsTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.sum, pie.IntsSum(test.ss))
 		})
 	}
 }
@@ -302,14 +214,6 @@ func TestInts_Len(t *testing.T) {
 	for _, test := range intsStatsTests {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, test.len, pie.Ints(test.ss).Len())
-		})
-	}
-}
-
-func TestIntsAverage(t *testing.T) {
-	for _, test := range intsStatsTests {
-		t.Run("", func(t *testing.T) {
-			assert.Equal(t, test.average, pie.IntsAverage(test.ss))
 		})
 	}
 }

--- a/strings.go
+++ b/strings.go
@@ -38,9 +38,9 @@ import (
 //
 type Strings []string
 
-// StringsContains returns true if the string exists in the slice. The strings
-// must be exactly equal (case-sensitive).
-func StringsContains(ss []string, lookingFor string) bool {
+// Contains returns true if the string exists in the slice. The strings must be
+// exactly equal (case-sensitive).
+func (ss Strings) Contains(lookingFor string) bool {
 	for _, s := range ss {
 		if s == lookingFor {
 			return true
@@ -50,16 +50,11 @@ func StringsContains(ss []string, lookingFor string) bool {
 	return false
 }
 
-// Contains is the chained version of StringsContains.
-func (ss Strings) Contains(lookingFor string) bool {
-	return StringsContains(ss, lookingFor)
-}
-
-// StringsOnly will return a new slice containing only the elements that return
-// true from the condition. The returned slice may contain zero elements (nil).
+// Only will return a new slice containing only the elements that return true
+// from the condition. The returned slice may contain zero elements (nil).
 //
 // StringsWithout works in the opposite way as StringsOnly.
-func StringsOnly(ss []string, condition StringConditionFunc) (ss2 []string) {
+func (ss Strings) Only(condition StringConditionFunc) (ss2 Strings) {
 	for _, s := range ss {
 		if condition(s) {
 			ss2 = append(ss2, s)
@@ -69,15 +64,10 @@ func StringsOnly(ss []string, condition StringConditionFunc) (ss2 []string) {
 	return
 }
 
-// Only is the chained version of StringsOnly.
-func (ss Strings) Only(condition StringConditionFunc) (ss2 Strings) {
-	return StringsOnly(ss, condition)
-}
-
-// StringsWithout works the same as StringsOnly, with a negated condition. That
-// is, it will return a new slice only containing the elements that returned
-// false from the condition. The returned slice may contain zero elements (nil).
-func StringsWithout(ss []string, condition StringConditionFunc) (ss2 []string) {
+// Without works the same as StringsOnly, with a negated condition. That is, it
+// will return a new slice only containing the elements that returned false from
+// the condition. The returned slice may contain zero elements (nil).
+func (ss Strings) Without(condition StringConditionFunc) (ss2 Strings) {
 	for _, s := range ss {
 		if !condition(s) {
 			ss2 = append(ss2, s)
@@ -87,15 +77,9 @@ func StringsWithout(ss []string, condition StringConditionFunc) (ss2 []string) {
 	return
 }
 
-// Without is the chained version of StringsWithout.
-func (ss Strings) Without(condition StringConditionFunc) (ss2 Strings) {
-	return StringsWithout(ss, condition)
-}
-
-// StringsTransform will return a new slice where each element has been
-// transformed. The number of element returned will always be the same as the
-// input.
-func StringsTransform(ss []string, fn StringTransformFunc) (ss2 []string) {
+// Transform will return a new slice where each element has been transformed.
+// The number of element returned will always be the same as the input.
+func (ss Strings) Transform(fn StringTransformFunc) (ss2 Strings) {
 	if ss == nil {
 		return nil
 	}
@@ -108,14 +92,9 @@ func StringsTransform(ss []string, fn StringTransformFunc) (ss2 []string) {
 	return
 }
 
-// Transform is the chained version of StringsTransform.
-func (ss Strings) Transform(fn StringTransformFunc) (ss2 Strings) {
-	return StringsTransform(ss, fn)
-}
-
-// StringsFirstOr returns the first element or a default value if there are no
+// FirstOr returns the first element or a default value if there are no
 // elements.
-func StringsFirstOr(ss []string, defaultValue string) string {
+func (ss Strings) FirstOr(defaultValue string) string {
 	if len(ss) == 0 {
 		return defaultValue
 	}
@@ -123,14 +102,8 @@ func StringsFirstOr(ss []string, defaultValue string) string {
 	return ss[0]
 }
 
-// FirstOr is the chained version of StringsFirstOr.
-func (ss Strings) FirstOr(defaultValue string) string {
-	return StringsFirstOr(ss, defaultValue)
-}
-
-// StringsLastOr returns the last element or a default value if there are no
-// elements.
-func StringsLastOr(ss []string, defaultValue string) string {
+// LastOr returns the last element or a default value if there are no elements.
+func (ss Strings) LastOr(defaultValue string) string {
 	if len(ss) == 0 {
 		return defaultValue
 	}
@@ -138,31 +111,14 @@ func StringsLastOr(ss []string, defaultValue string) string {
 	return ss[len(ss)-1]
 }
 
-// LastOr is the chained version of StringsLastOr.
-func (ss Strings) LastOr(defaultValue string) string {
-	return StringsLastOr(ss, defaultValue)
-}
-
-// StringsFirst returns the first element, or an empty string. Also see
-// StringsFirstOr.
-func StringsFirst(ss []string) string {
-	return StringsFirstOr(ss, "")
-}
-
-// First is the chained version of StringsFirst.
+// First returns the first element, or an empty string. Also see FirstOr().
 func (ss Strings) First() string {
-	return StringsFirst(ss)
+	return ss.FirstOr("")
 }
 
-// StringsLast returns the last element, or an empty string. Also see
-// StringsLastOr.
-func StringsLast(ss []string) string {
-	return StringsLastOr(ss, "")
-}
-
-// Last is the chained version of StringsLast.
+// Last returns the last element, or an empty string. Also see LastOr().
 func (ss Strings) Last() string {
-	return StringsLast(ss)
+	return ss.LastOr("")
 }
 
 // Len returns the number of elements.
@@ -170,8 +126,8 @@ func (ss Strings) Len() int {
 	return len(ss)
 }
 
-// StringsMin is the minimum value, or an empty string.
-func StringsMin(ss []string) (min string) {
+// Min is the minimum value, or an empty string.
+func (ss Strings) Min() (min string) {
 	if len(ss) == 0 {
 		return
 	}
@@ -186,13 +142,8 @@ func StringsMin(ss []string) (min string) {
 	return
 }
 
-// Min is the chained version of StringsMin.
-func (ss Strings) Min() string {
-	return StringsMin(ss)
-}
-
-// StringsMax is the maximum value, or en empty string.
-func StringsMax(ss []string) (max string) {
+// Max is the maximum value, or en empty string.
+func (ss Strings) Max() (max string) {
 	if len(ss) == 0 {
 		return
 	}
@@ -205,11 +156,6 @@ func StringsMax(ss []string) (max string) {
 	}
 
 	return
-}
-
-// Max is the chained version of StringsMax.
-func (ss Strings) Max() string {
-	return StringsMax(ss)
 }
 
 // JSONString returns the JSON encoded array as a string.

--- a/strings_test.go
+++ b/strings_test.go
@@ -32,15 +32,6 @@ func TestStrings_Contains(t *testing.T) {
 	}
 }
 
-func TestStringsContains(t *testing.T) {
-	for _, test := range stringsContainsTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, test.expected, pie.StringsContains(test.ss, test.contains))
-		})
-	}
-}
-
 var stringsOnlyAndWithoutTests = []struct {
 	ss                pie.Strings
 	condition         func(string) bool
@@ -77,15 +68,6 @@ func TestStrings_Only(t *testing.T) {
 	}
 }
 
-func TestStringsOnly(t *testing.T) {
-	for _, test := range stringsOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, []string(test.expectedOnly), pie.StringsOnly(test.ss, test.condition))
-		})
-	}
-}
-
 func TestStrings_Without(t *testing.T) {
 	for _, test := range stringsOnlyAndWithoutTests {
 		t.Run("", func(t *testing.T) {
@@ -95,29 +77,11 @@ func TestStrings_Without(t *testing.T) {
 	}
 }
 
-func TestStringsWithout(t *testing.T) {
-	for _, test := range stringsOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, []string(test.expectedWithout), pie.StringsWithout(test.ss, test.condition))
-		})
-	}
-}
-
 func TestStrings_Transform(t *testing.T) {
 	for _, test := range stringsOnlyAndWithoutTests {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableStrings(t, &test.ss)()
 			assert.Equal(t, test.expectedTransform, test.ss.Transform(strings.ToUpper))
-		})
-	}
-}
-
-func TestStringsTransform(t *testing.T) {
-	for _, test := range stringsOnlyAndWithoutTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, []string(test.expectedTransform), pie.StringsTransform(test.ss, strings.ToUpper))
 		})
 	}
 }
@@ -166,29 +130,11 @@ func TestStrings_FirstOr(t *testing.T) {
 	}
 }
 
-func TestStringsFirstOr(t *testing.T) {
-	for _, test := range firstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, test.firstOr, pie.StringsFirstOr(test.ss, "default1"))
-		})
-	}
-}
-
 func TestStrings_LastOr(t *testing.T) {
 	for _, test := range firstAndLastTests {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableStrings(t, &test.ss)()
 			assert.Equal(t, test.lastOr, test.ss.LastOr("default2"))
-		})
-	}
-}
-
-func TestStringsLastOr(t *testing.T) {
-	for _, test := range firstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, test.lastOr, pie.StringsLastOr(test.ss, "default2"))
 		})
 	}
 }
@@ -202,29 +148,11 @@ func TestStrings_First(t *testing.T) {
 	}
 }
 
-func TestStringsFirst(t *testing.T) {
-	for _, test := range firstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, test.first, pie.StringsFirst(test.ss))
-		})
-	}
-}
-
 func TestStrings_Last(t *testing.T) {
 	for _, test := range firstAndLastTests {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableStrings(t, &test.ss)()
 			assert.Equal(t, test.last, test.ss.Last())
-		})
-	}
-}
-
-func TestStringsLast(t *testing.T) {
-	for _, test := range firstAndLastTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, test.last, pie.StringsLast(test.ss))
 		})
 	}
 }
@@ -260,29 +188,11 @@ var stringsStatsTests = []struct {
 	},
 }
 
-func TestStringsMin(t *testing.T) {
-	for _, test := range stringsStatsTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, test.min, pie.StringsMin(test.ss))
-		})
-	}
-}
-
 func TestStrings_Min(t *testing.T) {
 	for _, test := range stringsStatsTests {
 		t.Run("", func(t *testing.T) {
 			defer assertImmutableStrings(t, &test.ss)()
 			assert.Equal(t, test.min, pie.Strings(test.ss).Min())
-		})
-	}
-}
-
-func TestStringsMax(t *testing.T) {
-	for _, test := range stringsStatsTests {
-		t.Run("", func(t *testing.T) {
-			defer assertImmutableStrings(t, &test.ss)()
-			assert.Equal(t, test.max, pie.StringsMax(test.ss))
 		})
 	}
 }


### PR DESCRIPTION
It's temping to add package level functions, like `pie.StringsOnly(ss, fn)` as a shortcut for `pie.Strings(ss).Only(fn)`. In fact older versions did actually
have these. I removed them because:

1. The `pie` types are aliases so there is no special operation to use `[]string` and `pie.Strings` interchangeably.

2. It created a huge amount of duplicate code that also created lots of extra tests and more complicated documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/18)
<!-- Reviewable:end -->
