### PR TITLE
shuffle: support in go 1.8+

### DIFF
--- a/functions/shuffle.go
+++ b/functions/shuffle.go
@@ -1,20 +1,28 @@
 package functions
 
 import (
+	"github.com/elliotchance/pie/pie/util"
 	"math/rand"
 )
 
 // Shuffle returns shuffled slice by your rand.Source
 func (ss SliceType) Shuffle(source rand.Source) SliceType {
-	if len(ss) < 2 {
+	n := len(ss)
+
+	// Avoid the extra allocation.
+	if n < 2 {
 		return ss
 	}
 
-	shuffled := make([]ElementType, len(ss))
+	// go 1.10+ provides rnd.Shuffle. However, to support older versions we copy
+	// the algorithm directly from the go source: src/math/rand/rand.go below,
+	// with some adjustments:
+	shuffled := make([]ElementType, n)
 	copy(shuffled, ss)
 
 	rnd := rand.New(source)
-	rnd.Shuffle(len(shuffled), func(i, j int) {
+
+	util.Shuffle(rnd, n, func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 

--- a/pie/carpointers_pie.go
+++ b/pie/carpointers_pie.go
@@ -2,6 +2,7 @@ package pie
 
 import (
 	"encoding/json"
+	"github.com/elliotchance/pie/pie/util"
 	"math/rand"
 )
 
@@ -154,15 +155,22 @@ func (ss carPointers) Select(condition func(*car) bool) (ss2 carPointers) {
 
 // Shuffle returns shuffled slice by your rand.Source
 func (ss carPointers) Shuffle(source rand.Source) carPointers {
-	if len(ss) < 2 {
+	n := len(ss)
+
+	// Avoid the extra allocation.
+	if n < 2 {
 		return ss
 	}
 
-	shuffled := make([]*car, len(ss))
+	// go 1.10+ provides rnd.Shuffle. However, to support older versions we copy
+	// the algorithm directly from the go source: src/math/rand/rand.go below,
+	// with some adjustments:
+	shuffled := make([]*car, n)
 	copy(shuffled, ss)
 
 	rnd := rand.New(source)
-	rnd.Shuffle(len(shuffled), func(i, j int) {
+
+	util.Shuffle(rnd, n, func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 

--- a/pie/cars_pie.go
+++ b/pie/cars_pie.go
@@ -2,6 +2,7 @@ package pie
 
 import (
 	"encoding/json"
+	"github.com/elliotchance/pie/pie/util"
 	"math/rand"
 )
 
@@ -154,15 +155,22 @@ func (ss cars) Select(condition func(car) bool) (ss2 cars) {
 
 // Shuffle returns shuffled slice by your rand.Source
 func (ss cars) Shuffle(source rand.Source) cars {
-	if len(ss) < 2 {
+	n := len(ss)
+
+	// Avoid the extra allocation.
+	if n < 2 {
 		return ss
 	}
 
-	shuffled := make([]car, len(ss))
+	// go 1.10+ provides rnd.Shuffle. However, to support older versions we copy
+	// the algorithm directly from the go source: src/math/rand/rand.go below,
+	// with some adjustments:
+	shuffled := make([]car, n)
 	copy(shuffled, ss)
 
 	rnd := rand.New(source)
-	rnd.Shuffle(len(shuffled), func(i, j int) {
+
+	util.Shuffle(rnd, n, func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 

--- a/pie/float64s_pie.go
+++ b/pie/float64s_pie.go
@@ -2,6 +2,7 @@ package pie
 
 import (
 	"encoding/json"
+	"github.com/elliotchance/pie/pie/util"
 	"math/rand"
 	"sort"
 )
@@ -240,15 +241,22 @@ func (ss Float64s) Sum() (sum float64) {
 
 // Shuffle returns shuffled slice by your rand.Source
 func (ss Float64s) Shuffle(source rand.Source) Float64s {
-	if len(ss) < 2 {
+	n := len(ss)
+
+	// Avoid the extra allocation.
+	if n < 2 {
 		return ss
 	}
 
-	shuffled := make([]float64, len(ss))
+	// go 1.10+ provides rnd.Shuffle. However, to support older versions we copy
+	// the algorithm directly from the go source: src/math/rand/rand.go below,
+	// with some adjustments:
+	shuffled := make([]float64, n)
 	copy(shuffled, ss)
 
 	rnd := rand.New(source)
-	rnd.Shuffle(len(shuffled), func(i, j int) {
+
+	util.Shuffle(rnd, n, func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 

--- a/pie/ints_pie.go
+++ b/pie/ints_pie.go
@@ -2,6 +2,7 @@ package pie
 
 import (
 	"encoding/json"
+	"github.com/elliotchance/pie/pie/util"
 	"math/rand"
 	"sort"
 )
@@ -240,15 +241,22 @@ func (ss Ints) Sum() (sum int) {
 
 // Shuffle returns shuffled slice by your rand.Source
 func (ss Ints) Shuffle(source rand.Source) Ints {
-	if len(ss) < 2 {
+	n := len(ss)
+
+	// Avoid the extra allocation.
+	if n < 2 {
 		return ss
 	}
 
-	shuffled := make([]int, len(ss))
+	// go 1.10+ provides rnd.Shuffle. However, to support older versions we copy
+	// the algorithm directly from the go source: src/math/rand/rand.go below,
+	// with some adjustments:
+	shuffled := make([]int, n)
 	copy(shuffled, ss)
 
 	rnd := rand.New(source)
-	rnd.Shuffle(len(shuffled), func(i, j int) {
+
+	util.Shuffle(rnd, n, func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 

--- a/pie/strings_pie.go
+++ b/pie/strings_pie.go
@@ -2,6 +2,7 @@ package pie
 
 import (
 	"encoding/json"
+	"github.com/elliotchance/pie/pie/util"
 	"math/rand"
 	"sort"
 )
@@ -234,15 +235,22 @@ func (ss Strings) Sort() Strings {
 
 // Shuffle returns shuffled slice by your rand.Source
 func (ss Strings) Shuffle(source rand.Source) Strings {
-	if len(ss) < 2 {
+	n := len(ss)
+
+	// Avoid the extra allocation.
+	if n < 2 {
 		return ss
 	}
 
-	shuffled := make([]string, len(ss))
+	// go 1.10+ provides rnd.Shuffle. However, to support older versions we copy
+	// the algorithm directly from the go source: src/math/rand/rand.go below,
+	// with some adjustments:
+	shuffled := make([]string, n)
 	copy(shuffled, ss)
 
 	rnd := rand.New(source)
-	rnd.Shuffle(len(shuffled), func(i, j int) {
+
+	util.Shuffle(rnd, n, func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 

--- a/pie/util/rand.go
+++ b/pie/util/rand.go
@@ -1,0 +1,44 @@
+package util
+
+import "math/rand"
+
+// Int31n was copied from src/math/rand/rand.go to support Shuffle in go
+// versions before 1.10.
+func Int31n(r *rand.Rand, n int32) int32 {
+	v := r.Uint32()
+	prod := uint64(v) * uint64(n)
+	low := uint32(prod)
+	if low < uint32(n) {
+		thresh := uint32(-n) % uint32(n)
+		for low < thresh {
+			v = r.Uint32()
+			prod = uint64(v) * uint64(n)
+			low = uint32(prod)
+		}
+	}
+	return int32(prod >> 32)
+}
+
+// Shuffle was copied from src/math/rand/rand.go to support Shuffle in go
+// versions before 1.10.
+func Shuffle(r *rand.Rand, n int, swap func(i, j int)) {
+	if n < 0 {
+		panic("invalid argument to Shuffle")
+	}
+
+	// Fisher-Yates shuffle: https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+	// Shuffle really ought not be called with n that doesn't fit in 32 bits.
+	// Not only will it take a very long time, but with 2³¹! possible permutations,
+	// there's no way that any PRNG can have a big enough internal state to
+	// generate even a minuscule percentage of the possible permutations.
+	// Nevertheless, the right API signature accepts an int n, so handle it as best we can.
+	i := n - 1
+	for ; i > 1<<31-1-1; i-- {
+		j := int(r.Int63n(int64(i + 1)))
+		swap(i, j)
+	}
+	for ; i > 0; i-- {
+		j := int(Int31n(r, int32(i+1)))
+		swap(i, j)
+	}
+}

--- a/template.go
+++ b/template.go
@@ -289,20 +289,28 @@ func (ss SliceType) Select(condition func(ElementType) bool) (ss2 SliceType) {
 	"Shuffle": `package functions
 
 import (
+	"github.com/elliotchance/pie/pie/util"
 	"math/rand"
 )
 
 // Shuffle returns shuffled slice by your rand.Source
 func (ss SliceType) Shuffle(source rand.Source) SliceType {
-	if len(ss) < 2 {
+	n := len(ss)
+
+	// Avoid the extra allocation.
+	if n < 2 {
 		return ss
 	}
 
-	shuffled := make([]ElementType, len(ss))
+	// go 1.10+ provides rnd.Shuffle. However, to support older versions we copy
+	// the algorithm directly from the go source: src/math/rand/rand.go below,
+	// with some adjustments:
+	shuffled := make([]ElementType, n)
 	copy(shuffled, ss)
 
 	rnd := rand.New(source)
-	rnd.Shuffle(len(shuffled), func(i, j int) {
+
+	util.Shuffle(rnd, n, func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
 


### PR DESCRIPTION
rand.Shuffle is only available from go 1.10+.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/63)
<!-- Reviewable:end -->
