### PR TITLE
Update gitignore to include common vim files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,16 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 /.idea
+
+
+# Vim specific
+
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# # Session
+Session.vim


### PR DESCRIPTION
Hey Elliot,

I've added some vim specific ignores to the gitignore file. These are common things to exclude when people use vim. Mainly the issue of having swap files open while trying to make a commit. You don't want to ever commit those. 

It might be pretty specific to my use case at the moment, but vim is still a more or less common "IDE" for Go, and there's really no harm in including these in the gitignore :smiley:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/90)
<!-- Reviewable:end -->
