### PR TITLE
added: Diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,48 +122,49 @@ This will only generate `myInts.Average`, `myInts.Sum` and `myStrings.Filter`.
 
 # Functions
 
-| Function     | String | Number | Struct| Maps | Big-O    | Description |
-| ------------ | :----: | :----: | :----:| :--: | :------: | ----------- |
-| `Abs`        |        | ✓      |       |      | n        | Abs will return the absolute value of all values in the slice.
-| `All`        | ✓      | ✓      | ✓     |      | n        | All will return true if all callbacks return true. If the list is empty then true is always returned. |
-| `Any`        | ✓      | ✓      | ✓     |      | n        | Any will return true if any callbacks return true. If the list is empty then false is always returned. |
-| `Append`     | ✓      | ✓      | ✓     |      | n        | A new slice with the elements appended to the end. |
-| `AreSorted`  | ✓      | ✓      |       |      | n        | Check if the slice is already sorted. |
-| `AreUnique`  | ✓      | ✓      |       |      | n        | Check if the slice contains only unique elements. |
-| `Average`    |        | ✓      |       |      | n        | The average (mean) value, or a zeroed value. |
-| `Bottom`     | ✓      | ✓      | ✓     |      | n        | Gets n elements from bottom. |
-| `Contains`   | ✓      | ✓      | ✓     |      | n        | Check if the value exists in the slice. |
-| `Extend`     | ✓      | ✓      | ✓     |      | n        | A new slice with the elements from each slice appended to the end. |
-| `Each`       | ✓      | ✓      | ✓     |      | n        | Perform an action on each element. |
-| `Filter`     | ✓      | ✓      | ✓     |      | n        | A new slice containing only the elements that returned true from the condition. |
-| `FilterNot`  | ✓      | ✓      | ✓     |      | n        | A new slice containing only the elements that returned false from the condition. |
-| `First`      | ✓      | ✓      | ✓     |      | 1        | The first element, or a zeroed value. |
-| `FirstOr`    | ✓      | ✓      | ✓     |      | 1        | The first element, or a default value. |
-| `Intersect`       | ✓      | ✓        |       |      | n | Intersect returns elements which exists in all slices. |
-| `Join`       | ✓      |        |       |      | n        | A string from joining each of the elements. |
-| `JSONString` | ✓      | ✓      | ✓     |      | n        | The JSON encoded string. |
-| `Keys`       |        |        |       | ✓    | n        | Returns all keys in the map (in random order). |
-| `Last`       | ✓      | ✓      | ✓     |      | 1        | The last element, or a zeroed value. |
-| `LastOr`     | ✓      | ✓      | ✓     |      | 1        | The last element, or a default value. |
-| `Len`        | ✓      | ✓      | ✓     |      | 1        | Number of elements. |
-| `Map`	       | ✓      | ✓      | ✓     |      | n        | A new slice where each element has been mapped (transformed). |
-| `Max`        | ✓      | ✓      |       |      | n        | The maximum value, or a zeroes value. |
-| `Median`     |        | ✓      |       |      | n⋅log(n) | Median returns the value separating the higher half from the lower half of a data sample. |
-| `Min`        | ✓      | ✓      |       |      | n        | The minimum value, or a zeroed value. |
-| `Product`    |        | ✓      |       |      | n        | Product of all elements. |
-| `Random`     | ✓      | ✓      | ✓     |      | 1        | Select a random element, or a zeroed value if empty. |
-| `Reduce`     | ✓      | ✓      |       |      | n        | Continously apply a function to the slice (left to right), reducing it to a single value. |
-| `Reverse`    | ✓      | ✓      | ✓     |      | n        | Reverse elements. |
-| `Send`       | ✓      | ✓      | ✓     |      | n        | Send all element to channel. |
-| `Sort`       | ✓      | ✓      |       |      | n⋅log(n) | Return a new sorted slice. |
-| `SortUsing`  | ✓      |        | ✓     |      | n⋅log(n) | Return a new sorted slice, using custom comparator. |
-| `SortStableUsing`  | ✓ |       | ✓     |      | n⋅log(n) | Return a new sorted slice, using custom comparator, keeping the original order of equal elements. |
-| `Sum`        |        | ✓      |       |      | n        | Sum (total) of all elements. |
-| `Shuffle`    | ✓      | ✓      | ✓     |      | n        | Returns a new shuffled slice. |
-| `Top`        | ✓      | ✓      | ✓     |      | n        | Gets several elements from top(head of slice).|
-| `ToStrings`  | ✓      | ✓      | ✓     |      | n        | Transforms each element to a string. |
-| `Unique`     | ✓      | ✓      |       |      | n        | Return a new slice with only unique elements. |
-| `Values`     |        |        |       | ✓    | n        | Returns all values in the map (in random order). |
+| Function          | String | Number | Struct | Maps | Big-O    | Description |
+| ----------------- | :----: | :----: | :----: | :--: | :------: | ----------- |
+| `Abs`             |        | ✓      |        |      | n        | Abs will return the absolute value of all values in the slice.
+| `All`             | ✓      | ✓      | ✓      |      | n        | All will return true if all callbacks return true. If the list is empty then true is always returned. |
+| `Any`             | ✓      | ✓      | ✓      |      | n        | Any will return true if any callbacks return true. If the list is empty then false is always returned. |
+| `Append`          | ✓      | ✓      | ✓      |      | n        | A new slice with the elements appended to the end. |
+| `AreSorted`       | ✓      | ✓      |        |      | n        | Check if the slice is already sorted. |
+| `AreUnique`       | ✓      | ✓      |        |      | n        | Check if the slice contains only unique elements. |
+| `Average`         |        | ✓      |        |      | n        | The average (mean) value, or a zeroed value. |
+| `Bottom`          | ✓      | ✓      | ✓      |      | n        | Gets n elements from bottom. |
+| `Contains`        | ✓      | ✓      | ✓      |      | n        | Check if the value exists in the slice. |
+| `Diff`            | ✓      | ✓      | ✓      |      | n²       | Diff returns the elements that needs to be added or removed from the first slice to have the same elements in the second slice. |
+| `Extend`          | ✓      | ✓      | ✓      |      | n        | A new slice with the elements from each slice appended to the end. |
+| `Each`            | ✓      | ✓      | ✓      |      | n        | Perform an action on each element. |
+| `Filter`          | ✓      | ✓      | ✓      |      | n        | A new slice containing only the elements that returned true from the condition. |
+| `FilterNot`       | ✓      | ✓      | ✓      |      | n        | A new slice containing only the elements that returned false from the condition. |
+| `First`           | ✓      | ✓      | ✓      |      | 1        | The first element, or a zeroed value. |
+| `FirstOr`         | ✓      | ✓      | ✓      |      | 1        | The first element, or a default value. |
+| `Intersect`       | ✓      | ✓      |        |      | n        | Intersect returns elements which exists in all slices. |
+| `Join`            | ✓      |        |        |      | n        | A string from joining each of the elements. |
+| `JSONString`      | ✓      | ✓      | ✓      |      | n        | The JSON encoded string. |
+| `Keys`            |        |        |        | ✓    | n        | Returns all keys in the map (in random order). |
+| `Last`            | ✓      | ✓      | ✓      |      | 1        | The last element, or a zeroed value. |
+| `LastOr`          | ✓      | ✓      | ✓      |      | 1        | The last element, or a default value. |
+| `Len`             | ✓      | ✓      | ✓      |      | 1        | Number of elements. |
+| `Map`	            | ✓      | ✓      | ✓      |      | n        | A new slice where each element has been mapped (transformed). |
+| `Max`             | ✓      | ✓      |        |      | n        | The maximum value, or a zeroes value. |
+| `Median`          |        | ✓      |        |      | n⋅log(n) | Median returns the value separating the higher half from the lower half of a data sample. |
+| `Min`             | ✓      | ✓      |        |      | n        | The minimum value, or a zeroed value. |
+| `Product`         |        | ✓      |        |      | n        | Product of all elements. |
+| `Random`          | ✓      | ✓      | ✓      |      | 1        | Select a random element, or a zeroed value if empty. |
+| `Reduce`          | ✓      | ✓      |        |      | n        | Continously apply a function to the slice (left to right), reducing it to a single value. |
+| `Reverse`         | ✓      | ✓      | ✓      |      | n        | Reverse elements. |
+| `Send`            | ✓      | ✓      | ✓      |      | n        | Send all element to channel. |
+| `Sort`            | ✓      | ✓      |        |      | n⋅log(n) | Return a new sorted slice. |
+| `SortUsing`       | ✓      |        | ✓      |      | n⋅log(n) | Return a new sorted slice, using custom comparator. |
+| `SortStableUsing` | ✓      |        | ✓      |      | n⋅log(n) | Return a new sorted slice, using custom comparator, keeping the original order of equal elements. |
+| `Sum`             |        | ✓      |        |      | n        | Sum (total) of all elements. |
+| `Shuffle`         | ✓      | ✓      | ✓      |      | n        | Returns a new shuffled slice. |
+| `Top`             | ✓      | ✓      | ✓      |      | n        | Gets several elements from top(head of slice).|
+| `ToStrings`       | ✓      | ✓      | ✓      |      | n        | Transforms each element to a string. |
+| `Unique`          | ✓      | ✓      |        |      | n        | Return a new slice with only unique elements. |
+| `Values`          |        |        |        | ✓    | n        | Returns all values in the map (in random order). |
 
 # FAQ
 

--- a/functions/diff.go
+++ b/functions/diff.go
@@ -1,0 +1,41 @@
+package functions
+
+// Diff returns the elements that needs to be added or removed from the first
+// slice to have the same elements in the second slice.
+//
+// The order of elements is not taken into consideration, so the slices are
+// treated sets that allow duplicate items.
+//
+// The added and removed returned may be blank respectively, or contain upto as
+// many elements that exists in the largest slice.
+func (ss SliceType) Diff(against SliceType) (added, removed SliceType) {
+	// This is probably not the best way to do it. We do an O(n^2) between the
+	// slices to see which items are missing in each direction.
+
+	diffOneWay := func(ss1, ss2raw SliceType) (result SliceType) {
+		ss2 := make(SliceType, len(ss2raw))
+		copy(ss2, ss2raw)
+
+		for _, s := range ss1 {
+			found := false
+
+			for i, element := range ss2 {
+				if element == s {
+					ss2 = append(ss2[:i], ss2[i+1:]...)
+					found = true
+				}
+			}
+
+			if !found {
+				result = append(result, s)
+			}
+		}
+
+		return
+	}
+
+	removed = diffOneWay(ss, against)
+	added = diffOneWay(against, ss)
+
+	return
+}

--- a/functions/main.go
+++ b/functions/main.go
@@ -27,6 +27,7 @@ var Functions = []struct {
 	{"Average", "average.go", ForNumbers},
 	{"Bottom", "bottom.go", ForAll},
 	{"Contains", "contains.go", ForAll},
+	{"Diff", "diff.go", ForAll},
 	{"Each", "each.go", ForAll},
 	{"Extend", "extend.go", ForAll},
 	{"Filter", "filter.go", ForAll},

--- a/pie/carpointers_pie.go
+++ b/pie/carpointers_pie.go
@@ -74,6 +74,46 @@ func (ss carPointers) Contains(lookingFor *car) bool {
 	return false
 }
 
+// Diff returns the elements that needs to be added or removed from the first
+// slice to have the same elements in the second slice.
+//
+// The order of elements is not taken into consideration, so the slices are
+// treated sets that allow duplicate items.
+//
+// The added and removed returned may be blank respectively, or contain upto as
+// many elements that exists in the largest slice.
+func (ss carPointers) Diff(against carPointers) (added, removed carPointers) {
+	// This is probably not the best way to do it. We do an O(n^2) between the
+	// slices to see which items are missing in each direction.
+
+	diffOneWay := func(ss1, ss2raw carPointers) (result carPointers) {
+		ss2 := make(carPointers, len(ss2raw))
+		copy(ss2, ss2raw)
+
+		for _, s := range ss1 {
+			found := false
+
+			for i, element := range ss2 {
+				if element == s {
+					ss2 = append(ss2[:i], ss2[i+1:]...)
+					found = true
+				}
+			}
+
+			if !found {
+				result = append(result, s)
+			}
+		}
+
+		return
+	}
+
+	removed = diffOneWay(ss, against)
+	added = diffOneWay(against, ss)
+
+	return
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/carpointers_test.go
+++ b/pie/carpointers_test.go
@@ -13,6 +13,9 @@ import (
 var carPointerA = &car{"a", "green"}
 var carPointerB = &car{"b", "blue"}
 var carPointerC = &car{"c", "gray"}
+var carPointerD = &car{"d", "black"}
+var carPointerE = &car{"e", "red"}
+var carPointerF = &car{"f", "yellow"}
 var carPointerEmpty = &car{}
 
 var carPointersContainsTests = []struct {
@@ -747,6 +750,69 @@ func TestCarPointers_Send(t *testing.T) {
 
 			assert.Equal(t, test.expected, actualSended)
 			assert.Equal(t, test.expected, actual())
+		})
+	}
+}
+
+var carPointersDiffTests = map[string]struct {
+	ss1     carPointers
+	ss2     carPointers
+	added   carPointers
+	removed carPointers
+}{
+	"BothEmpty": {
+		nil,
+		nil,
+		nil,
+		nil,
+	},
+	"OnlyRemovedUnique": {
+		carPointers{carPointerA, carPointerB},
+		nil,
+		nil,
+		carPointers{carPointerA, carPointerB},
+	},
+	"OnlyRemovedDuplicates": {
+		carPointers{carPointerA, carPointerC, carPointerA},
+		nil,
+		nil,
+		carPointers{carPointerA, carPointerC, carPointerA},
+	},
+	"OnlyAddedUnique": {
+		nil,
+		carPointers{carPointerB, carPointerC},
+		carPointers{carPointerB, carPointerC},
+		nil,
+	},
+	"OnlyAddedDuplicates": {
+		nil,
+		carPointers{carPointerB, carPointerC, carPointerC, carPointerB},
+		carPointers{carPointerB, carPointerC, carPointerC, carPointerB},
+		nil,
+	},
+	"AddedAndRemovedUnique": {
+		carPointers{carPointerA, carPointerB, carPointerC, carPointerD},
+		carPointers{carPointerC, carPointerD, carPointerE, carPointerF},
+		carPointers{carPointerE, carPointerF},
+		carPointers{carPointerA, carPointerB},
+	},
+	"AddedAndRemovedDuplicates": {
+		carPointers{carPointerA, carPointerB, carPointerC, carPointerC, carPointerD},
+		carPointers{carPointerC, carPointerD, carPointerE, carPointerD, carPointerF},
+		carPointers{carPointerE, carPointerD, carPointerF},
+		carPointers{carPointerA, carPointerB, carPointerC},
+	},
+}
+
+func TestCarPointers_Diff(t *testing.T) {
+	for testName, test := range carPointersDiffTests {
+		t.Run(testName, func(t *testing.T) {
+			defer assertImmutableCarPointers(t, &test.ss1)()
+			defer assertImmutableCarPointers(t, &test.ss2)()
+
+			added, removed := test.ss1.Diff(test.ss2)
+			assert.Equal(t, test.added, added)
+			assert.Equal(t, test.removed, removed)
 		})
 	}
 }

--- a/pie/cars_pie.go
+++ b/pie/cars_pie.go
@@ -74,6 +74,46 @@ func (ss cars) Contains(lookingFor car) bool {
 	return false
 }
 
+// Diff returns the elements that needs to be added or removed from the first
+// slice to have the same elements in the second slice.
+//
+// The order of elements is not taken into consideration, so the slices are
+// treated sets that allow duplicate items.
+//
+// The added and removed returned may be blank respectively, or contain upto as
+// many elements that exists in the largest slice.
+func (ss cars) Diff(against cars) (added, removed cars) {
+	// This is probably not the best way to do it. We do an O(n^2) between the
+	// slices to see which items are missing in each direction.
+
+	diffOneWay := func(ss1, ss2raw cars) (result cars) {
+		ss2 := make(cars, len(ss2raw))
+		copy(ss2, ss2raw)
+
+		for _, s := range ss1 {
+			found := false
+
+			for i, element := range ss2 {
+				if element == s {
+					ss2 = append(ss2[:i], ss2[i+1:]...)
+					found = true
+				}
+			}
+
+			if !found {
+				result = append(result, s)
+			}
+		}
+
+		return
+	}
+
+	removed = diffOneWay(ss, against)
+	added = diffOneWay(against, ss)
+
+	return
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/cars_test.go
+++ b/pie/cars_test.go
@@ -734,3 +734,66 @@ func TestCar_Send(t *testing.T) {
 		})
 	}
 }
+
+var carsDiffTests = map[string]struct {
+	ss1     cars
+	ss2     cars
+	added   cars
+	removed cars
+}{
+	"BothEmpty": {
+		nil,
+		nil,
+		nil,
+		nil,
+	},
+	"OnlyRemovedUnique": {
+		cars{car{"a", "green"}, car{"bar", "yellow"}},
+		nil,
+		nil,
+		cars{car{"a", "green"}, car{"bar", "yellow"}},
+	},
+	"OnlyRemovedDuplicates": {
+		cars{car{"a", "green"}, car{"Baz", "black"}, car{"a", "green"}},
+		nil,
+		nil,
+		cars{car{"a", "green"}, car{"Baz", "black"}, car{"a", "green"}},
+	},
+	"OnlyAddedUnique": {
+		nil,
+		cars{car{"bar", "yellow"}, car{"Baz", "black"}},
+		cars{car{"bar", "yellow"}, car{"Baz", "black"}},
+		nil,
+	},
+	"OnlyAddedDuplicates": {
+		nil,
+		cars{car{"bar", "yellow"}, car{"Baz", "black"}, car{"Baz", "black"}, car{"bar", "yellow"}},
+		cars{car{"bar", "yellow"}, car{"Baz", "black"}, car{"Baz", "black"}, car{"bar", "yellow"}},
+		nil,
+	},
+	"AddedAndRemovedUnique": {
+		cars{car{"a", "green"}, car{"bar", "yellow"}, car{"Baz", "black"}, car{"qux", "grey"}},
+		cars{car{"Baz", "black"}, car{"qux", "grey"}, car{"quux", "red"}, car{"Baz", "magenta"}},
+		cars{car{"quux", "red"}, car{"Baz", "magenta"}},
+		cars{car{"a", "green"}, car{"bar", "yellow"}},
+	},
+	"AddedAndRemovedDuplicates": {
+		cars{car{"a", "green"}, car{"bar", "yellow"}, car{"Baz", "black"}, car{"Baz", "black"}, car{"qux", "grey"}},
+		cars{car{"Baz", "black"}, car{"qux", "grey"}, car{"quux", "red"}, car{"qux", "grey"}, car{"Baz", "magenta"}},
+		cars{car{"quux", "red"}, car{"qux", "grey"}, car{"Baz", "magenta"}},
+		cars{car{"a", "green"}, car{"bar", "yellow"}, car{"Baz", "black"}},
+	},
+}
+
+func TestCars_Diff(t *testing.T) {
+	for testName, test := range carsDiffTests {
+		t.Run(testName, func(t *testing.T) {
+			defer assertImmutableCars(t, &test.ss1)()
+			defer assertImmutableCars(t, &test.ss2)()
+
+			added, removed := test.ss1.Diff(test.ss2)
+			assert.Equal(t, test.added, added)
+			assert.Equal(t, test.removed, removed)
+		})
+	}
+}

--- a/pie/float64s_pie.go
+++ b/pie/float64s_pie.go
@@ -108,6 +108,46 @@ func (ss Float64s) Contains(lookingFor float64) bool {
 	return false
 }
 
+// Diff returns the elements that needs to be added or removed from the first
+// slice to have the same elements in the second slice.
+//
+// The order of elements is not taken into consideration, so the slices are
+// treated sets that allow duplicate items.
+//
+// The added and removed returned may be blank respectively, or contain upto as
+// many elements that exists in the largest slice.
+func (ss Float64s) Diff(against Float64s) (added, removed Float64s) {
+	// This is probably not the best way to do it. We do an O(n^2) between the
+	// slices to see which items are missing in each direction.
+
+	diffOneWay := func(ss1, ss2raw Float64s) (result Float64s) {
+		ss2 := make(Float64s, len(ss2raw))
+		copy(ss2, ss2raw)
+
+		for _, s := range ss1 {
+			found := false
+
+			for i, element := range ss2 {
+				if element == s {
+					ss2 = append(ss2[:i], ss2[i+1:]...)
+					found = true
+				}
+			}
+
+			if !found {
+				result = append(result, s)
+			}
+		}
+
+		return
+	}
+
+	removed = diffOneWay(ss, against)
+	added = diffOneWay(against, ss)
+
+	return
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/float64s_test.go
+++ b/pie/float64s_test.go
@@ -901,3 +901,66 @@ func TestFloat64s_Intersect(t *testing.T) {
 		})
 	}
 }
+
+var float64sDiffTests = map[string]struct {
+	ss1     Float64s
+	ss2     Float64s
+	added   Float64s
+	removed Float64s
+}{
+	"BothEmpty": {
+		nil,
+		nil,
+		nil,
+		nil,
+	},
+	"OnlyRemovedUnique": {
+		Float64s{4334.5435, 879.123},
+		nil,
+		nil,
+		Float64s{4334.5435, 879.123},
+	},
+	"OnlyRemovedDuplicates": {
+		Float64s{4334.5435, 92.384, 4334.5435},
+		nil,
+		nil,
+		Float64s{4334.5435, 92.384, 4334.5435},
+	},
+	"OnlyAddedUnique": {
+		nil,
+		Float64s{879.123, 92.384},
+		Float64s{879.123, 92.384},
+		nil,
+	},
+	"OnlyAddedDuplicates": {
+		nil,
+		Float64s{879.123, 92.384, 92.384, 879.123},
+		Float64s{879.123, 92.384, 92.384, 879.123},
+		nil,
+	},
+	"AddedAndRemovedUnique": {
+		Float64s{4334.5435, 879.123, 92.384, 823.324},
+		Float64s{92.384, 823.324, 453, 3.345},
+		Float64s{453, 3.345},
+		Float64s{4334.5435, 879.123},
+	},
+	"AddedAndRemovedDuplicates": {
+		Float64s{4334.5435, 879.123, 92.384, 92.384, 823.324},
+		Float64s{92.384, 823.324, 453, 823.324, 3.345},
+		Float64s{453, 823.324, 3.345},
+		Float64s{4334.5435, 879.123, 92.384},
+	},
+}
+
+func TestFloat64s_Diff(t *testing.T) {
+	for testName, test := range float64sDiffTests {
+		t.Run(testName, func(t *testing.T) {
+			defer assertImmutableFloat64s(t, &test.ss1)()
+			defer assertImmutableFloat64s(t, &test.ss2)()
+
+			added, removed := test.ss1.Diff(test.ss2)
+			assert.Equal(t, test.added, added)
+			assert.Equal(t, test.removed, removed)
+		})
+	}
+}

--- a/pie/ints_pie.go
+++ b/pie/ints_pie.go
@@ -108,6 +108,46 @@ func (ss Ints) Contains(lookingFor int) bool {
 	return false
 }
 
+// Diff returns the elements that needs to be added or removed from the first
+// slice to have the same elements in the second slice.
+//
+// The order of elements is not taken into consideration, so the slices are
+// treated sets that allow duplicate items.
+//
+// The added and removed returned may be blank respectively, or contain upto as
+// many elements that exists in the largest slice.
+func (ss Ints) Diff(against Ints) (added, removed Ints) {
+	// This is probably not the best way to do it. We do an O(n^2) between the
+	// slices to see which items are missing in each direction.
+
+	diffOneWay := func(ss1, ss2raw Ints) (result Ints) {
+		ss2 := make(Ints, len(ss2raw))
+		copy(ss2, ss2raw)
+
+		for _, s := range ss1 {
+			found := false
+
+			for i, element := range ss2 {
+				if element == s {
+					ss2 = append(ss2[:i], ss2[i+1:]...)
+					found = true
+				}
+			}
+
+			if !found {
+				result = append(result, s)
+			}
+		}
+
+		return
+	}
+
+	removed = diffOneWay(ss, against)
+	added = diffOneWay(against, ss)
+
+	return
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/ints_test.go
+++ b/pie/ints_test.go
@@ -866,3 +866,66 @@ func TestInts_Intersect(t *testing.T) {
 		})
 	}
 }
+
+var intsDiffTests = map[string]struct {
+	ss1     Ints
+	ss2     Ints
+	added   Ints
+	removed Ints
+}{
+	"BothEmpty": {
+		nil,
+		nil,
+		nil,
+		nil,
+	},
+	"OnlyRemovedUnique": {
+		Ints{1, 3},
+		nil,
+		nil,
+		Ints{1, 3},
+	},
+	"OnlyRemovedDuplicates": {
+		Ints{1, 3, 1},
+		nil,
+		nil,
+		Ints{1, 3, 1},
+	},
+	"OnlyAddedUnique": {
+		nil,
+		Ints{2, 3},
+		Ints{2, 3},
+		nil,
+	},
+	"OnlyAddedDuplicates": {
+		nil,
+		Ints{2, 3, 3, 2},
+		Ints{2, 3, 3, 2},
+		nil,
+	},
+	"AddedAndRemovedUnique": {
+		Ints{1, 2, 3, 4},
+		Ints{3, 4, 5, 6},
+		Ints{5, 6},
+		Ints{1, 2},
+	},
+	"AddedAndRemovedDuplicates": {
+		Ints{1, 2, 3, 3, 4},
+		Ints{3, 4, 5, 4, 6},
+		Ints{5, 4, 6},
+		Ints{1, 2, 3},
+	},
+}
+
+func TestInts_Diff(t *testing.T) {
+	for testName, test := range intsDiffTests {
+		t.Run(testName, func(t *testing.T) {
+			defer assertImmutableInts(t, &test.ss1)()
+			defer assertImmutableInts(t, &test.ss2)()
+
+			added, removed := test.ss1.Diff(test.ss2)
+			assert.Equal(t, test.added, added)
+			assert.Equal(t, test.removed, removed)
+		})
+	}
+}

--- a/pie/strings_pie.go
+++ b/pie/strings_pie.go
@@ -88,6 +88,46 @@ func (ss Strings) Contains(lookingFor string) bool {
 	return false
 }
 
+// Diff returns the elements that needs to be added or removed from the first
+// slice to have the same elements in the second slice.
+//
+// The order of elements is not taken into consideration, so the slices are
+// treated sets that allow duplicate items.
+//
+// The added and removed returned may be blank respectively, or contain upto as
+// many elements that exists in the largest slice.
+func (ss Strings) Diff(against Strings) (added, removed Strings) {
+	// This is probably not the best way to do it. We do an O(n^2) between the
+	// slices to see which items are missing in each direction.
+
+	diffOneWay := func(ss1, ss2raw Strings) (result Strings) {
+		ss2 := make(Strings, len(ss2raw))
+		copy(ss2, ss2raw)
+
+		for _, s := range ss1 {
+			found := false
+
+			for i, element := range ss2 {
+				if element == s {
+					ss2 = append(ss2[:i], ss2[i+1:]...)
+					found = true
+				}
+			}
+
+			if !found {
+				result = append(result, s)
+			}
+		}
+
+		return
+	}
+
+	removed = diffOneWay(ss, against)
+	added = diffOneWay(against, ss)
+
+	return
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/strings_test.go
+++ b/pie/strings_test.go
@@ -888,3 +888,66 @@ func TestStrings_Intersect(t *testing.T) {
 		})
 	}
 }
+
+var stringsDiffTests = map[string]struct {
+	ss1     Strings
+	ss2     Strings
+	added   Strings
+	removed Strings
+}{
+	"BothEmpty": {
+		nil,
+		nil,
+		nil,
+		nil,
+	},
+	"OnlyRemovedUnique": {
+		Strings{"foo", "bar"},
+		nil,
+		nil,
+		Strings{"foo", "bar"},
+	},
+	"OnlyRemovedDuplicates": {
+		Strings{"foo", "baz", "foo"},
+		nil,
+		nil,
+		Strings{"foo", "baz", "foo"},
+	},
+	"OnlyAddedUnique": {
+		nil,
+		Strings{"bar", "baz"},
+		Strings{"bar", "baz"},
+		nil,
+	},
+	"OnlyAddedDuplicates": {
+		nil,
+		Strings{"bar", "baz", "baz", "bar"},
+		Strings{"bar", "baz", "baz", "bar"},
+		nil,
+	},
+	"AddedAndRemovedUnique": {
+		Strings{"foo", "bar", "baz", "qux"},
+		Strings{"baz", "qux", "quux", "corge"},
+		Strings{"quux", "corge"},
+		Strings{"foo", "bar"},
+	},
+	"AddedAndRemovedDuplicates": {
+		Strings{"foo", "bar", "baz", "baz", "qux"},
+		Strings{"baz", "qux", "quux", "qux", "corge"},
+		Strings{"quux", "qux", "corge"},
+		Strings{"foo", "bar", "baz"},
+	},
+}
+
+func TestStrings_Diff(t *testing.T) {
+	for testName, test := range stringsDiffTests {
+		t.Run(testName, func(t *testing.T) {
+			defer assertImmutableStrings(t, &test.ss1)()
+			defer assertImmutableStrings(t, &test.ss2)()
+
+			added, removed := test.ss1.Diff(test.ss2)
+			assert.Equal(t, test.added, added)
+			assert.Equal(t, test.removed, removed)
+		})
+	}
+}

--- a/template.go
+++ b/template.go
@@ -127,6 +127,48 @@ func (ss SliceType) Contains(lookingFor ElementType) bool {
 	return false
 }
 `,
+	"Diff": `package functions
+
+// Diff returns the elements that needs to be added or removed from the first
+// slice to have the same elements in the second slice.
+//
+// The order of elements is not taken into consideration, so the slices are
+// treated sets that allow duplicate items.
+//
+// The added and removed returned may be blank respectively, or contain upto as
+// many elements that exists in the largest slice.
+func (ss SliceType) Diff(against SliceType) (added, removed SliceType) {
+	// This is probably not the best way to do it. We do an O(n^2) between the
+	// slices to see which items are missing in each direction.
+
+	diffOneWay := func(ss1, ss2raw SliceType) (result SliceType) {
+		ss2 := make(SliceType, len(ss2raw))
+		copy(ss2, ss2raw)
+
+		for _, s := range ss1 {
+			found := false
+
+			for i, element := range ss2 {
+				if element == s {
+					ss2 = append(ss2[:i], ss2[i+1:]...)
+					found = true
+				}
+			}
+
+			if !found {
+				result = append(result, s)
+			}
+		}
+
+		return
+	}
+
+	removed = diffOneWay(ss, against)
+	added = diffOneWay(against, ss)
+
+	return
+}
+`,
 	"Each": `package functions
 
 // Each is more condensed version of Transform that allows an action to happen


### PR DESCRIPTION
Diff returns the elements that need to be added or removed from the first slice to have the same elements in the second slice.

The order of elements is not taken into consideration, so the slices are treated sets that allow duplicate items.

The added and removed returned may be blank respectively or contain up to as many elements that exist in the largest slice.

Fixes #75

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/112)
<!-- Reviewable:end -->
