### PR TITLE
added: custom equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ focuses on type safety, performance and immutability.
   * [Install/Update](#install-update)
   * [Built-in Types](#built-in-types)
   * [Custom Types](#custom-types)
+  * [Custom Equality](#custom-equality)
   * [Limiting Functions Generated](#limiting-functions-generated)
 - [Functions](#functions)
 - [FAQ](#faq)
@@ -108,6 +109,33 @@ cars.FilterNot(func (car Car) {
 // Car{"SALLY", "green"}
 ```
 
+## Custom Equality
+
+Some functions that compare elements, such as Contains will use the following
+method if it is available on the element type:
+
+```go
+func (a ElementType) Equals(b ElementType) bool
+```
+
+The `ElementType` must be the same for the receiver and argument and it must
+return a bool. Be careful to create the function on the pointer or non-pointer
+type that is used by the slice.
+
+Here is a minimal example:
+
+```go
+type Car struct {
+	Name, Color string
+}
+
+type Cars []*Car // ElementType is *Car
+
+func (c *Car) Equals(c2 *Car) bool {
+	return c.Name == c2.Name
+}
+```
+
 ## Limiting Functions Generated
 
 The `.*` can be used to generate all functions. This is easy to get going but
@@ -122,6 +150,11 @@ This will only generate `myInts.Average`, `myInts.Sum` and `myStrings.Filter`.
 
 # Functions
 
+Below is a summary of the available functions.
+
+The "(E)" after the function name indicates that the function will use the
+`Equals` method if it is available. See *Custom Equality*.
+
 | Function          | String | Number | Struct | Maps | Big-O    | Description |
 | ----------------- | :----: | :----: | :----: | :--: | :------: | ----------- |
 | `Abs`             |        | ✓      |        |      | n        | Abs will return the absolute value of all values in the slice.
@@ -132,8 +165,8 @@ This will only generate `myInts.Average`, `myInts.Sum` and `myStrings.Filter`.
 | `AreUnique`       | ✓      | ✓      |        |      | n        | Check if the slice contains only unique elements. |
 | `Average`         |        | ✓      |        |      | n        | The average (mean) value, or a zeroed value. |
 | `Bottom`          | ✓      | ✓      | ✓      |      | n        | Gets n elements from bottom. |
-| `Contains`        | ✓      | ✓      | ✓      |      | n        | Check if the value exists in the slice. |
-| `Diff`            | ✓      | ✓      | ✓      |      | n²       | Diff returns the elements that needs to be added or removed from the first slice to have the same elements in the second slice. |
+| `Contains` (E)    | ✓      | ✓      | ✓      |      | n        | Check if the value exists in the slice. |
+| `Diff` (E)        | ✓      | ✓      | ✓      |      | n²       | Diff returns the elements that needs to be added or removed from the first slice to have the same elements in the second slice. |
 | `Extend`          | ✓      | ✓      | ✓      |      | n        | A new slice with the elements from each slice appended to the end. |
 | `Each`            | ✓      | ✓      | ✓      |      | n        | Perform an action on each element. |
 | `Filter`          | ✓      | ✓      | ✓      |      | n        | A new slice containing only the elements that returned true from the condition. |

--- a/functions/contains.go
+++ b/functions/contains.go
@@ -5,7 +5,7 @@ package functions
 // When using slices of pointers it will only compare by address, not value.
 func (ss SliceType) Contains(lookingFor ElementType) bool {
 	for _, s := range ss {
-		if s == lookingFor {
+		if lookingFor.Equals(s) {
 			return true
 		}
 	}

--- a/functions/diff.go
+++ b/functions/diff.go
@@ -20,7 +20,7 @@ func (ss SliceType) Diff(against SliceType) (added, removed SliceType) {
 			found := false
 
 			for i, element := range ss2 {
-				if element == s {
+				if s.Equals(element) {
 					ss2 = append(ss2[:i], ss2[i+1:]...)
 					found = true
 				}

--- a/functions/main.go
+++ b/functions/main.go
@@ -70,3 +70,7 @@ type KeySliceType []KeyType
 type MapType map[KeyType]ElementType
 
 var ElementZeroValue ElementType
+
+func (a ElementType) Equals(b ElementType) bool {
+	return a == b
+}

--- a/pie/car.go
+++ b/pie/car.go
@@ -7,3 +7,15 @@ type carPointers []*car
 type car struct {
 	Name, Color string
 }
+
+func (c *car) Equals(c2 *car) bool {
+	if c == nil && c2 == nil {
+		return true
+	}
+
+	if c == nil || c2 == nil {
+		return false
+	}
+
+	return c.Name == c2.Name
+}

--- a/pie/carpointers_pie.go
+++ b/pie/carpointers_pie.go
@@ -66,7 +66,7 @@ func (ss carPointers) Bottom(n int) (top carPointers) {
 // When using slices of pointers it will only compare by address, not value.
 func (ss carPointers) Contains(lookingFor *car) bool {
 	for _, s := range ss {
-		if s == lookingFor {
+		if lookingFor.Equals(s) {
 			return true
 		}
 	}
@@ -94,7 +94,7 @@ func (ss carPointers) Diff(against carPointers) (added, removed carPointers) {
 			found := false
 
 			for i, element := range ss2 {
-				if element == s {
+				if s.Equals(element) {
 					ss2 = append(ss2[:i], ss2[i+1:]...)
 					found = true
 				}

--- a/pie/carpointers_test.go
+++ b/pie/carpointers_test.go
@@ -29,7 +29,7 @@ var carPointersContainsTests = []struct {
 	{carPointers{carPointerA, carPointerB, carPointerC}, carPointerA, true},
 	{carPointers{carPointerA, carPointerB, carPointerC}, carPointerB, true},
 	{carPointers{carPointerA, carPointerB, carPointerC}, carPointerC, true},
-	{carPointers{carPointerA, carPointerB, carPointerC}, &car{"a", "green"}, false},
+	{carPointers{carPointerA, carPointerB, carPointerC}, &car{"a", "green"}, true},
 	{carPointers{carPointerA, carPointerB, carPointerC}, &car{"A", ""}, false},
 	{carPointers{carPointerA, carPointerB, carPointerC}, &car{}, false},
 	{carPointers{carPointerA, carPointerB, carPointerC}, &car{"d", ""}, false},

--- a/pie/cars_pie.go
+++ b/pie/cars_pie.go
@@ -66,7 +66,7 @@ func (ss cars) Bottom(n int) (top cars) {
 // When using slices of pointers it will only compare by address, not value.
 func (ss cars) Contains(lookingFor car) bool {
 	for _, s := range ss {
-		if s == lookingFor {
+		if lookingFor == s {
 			return true
 		}
 	}
@@ -94,7 +94,7 @@ func (ss cars) Diff(against cars) (added, removed cars) {
 			found := false
 
 			for i, element := range ss2 {
-				if element == s {
+				if s == element {
 					ss2 = append(ss2[:i], ss2[i+1:]...)
 					found = true
 				}

--- a/pie/float64s_pie.go
+++ b/pie/float64s_pie.go
@@ -100,7 +100,7 @@ func (ss Float64s) Bottom(n int) (top Float64s) {
 // When using slices of pointers it will only compare by address, not value.
 func (ss Float64s) Contains(lookingFor float64) bool {
 	for _, s := range ss {
-		if s == lookingFor {
+		if lookingFor == s {
 			return true
 		}
 	}
@@ -128,7 +128,7 @@ func (ss Float64s) Diff(against Float64s) (added, removed Float64s) {
 			found := false
 
 			for i, element := range ss2 {
-				if element == s {
+				if s == element {
 					ss2 = append(ss2[:i], ss2[i+1:]...)
 					found = true
 				}

--- a/pie/ints_pie.go
+++ b/pie/ints_pie.go
@@ -100,7 +100,7 @@ func (ss Ints) Bottom(n int) (top Ints) {
 // When using slices of pointers it will only compare by address, not value.
 func (ss Ints) Contains(lookingFor int) bool {
 	for _, s := range ss {
-		if s == lookingFor {
+		if lookingFor == s {
 			return true
 		}
 	}
@@ -128,7 +128,7 @@ func (ss Ints) Diff(against Ints) (added, removed Ints) {
 			found := false
 
 			for i, element := range ss2 {
-				if element == s {
+				if s == element {
 					ss2 = append(ss2[:i], ss2[i+1:]...)
 					found = true
 				}

--- a/pie/strings_pie.go
+++ b/pie/strings_pie.go
@@ -80,7 +80,7 @@ func (ss Strings) Bottom(n int) (top Strings) {
 // When using slices of pointers it will only compare by address, not value.
 func (ss Strings) Contains(lookingFor string) bool {
 	for _, s := range ss {
-		if s == lookingFor {
+		if lookingFor == s {
 			return true
 		}
 	}
@@ -108,7 +108,7 @@ func (ss Strings) Diff(against Strings) (added, removed Strings) {
 			found := false
 
 			for i, element := range ss2 {
-				if element == s {
+				if s == element {
 					ss2 = append(ss2[:i], ss2[i+1:]...)
 					found = true
 				}

--- a/template.go
+++ b/template.go
@@ -119,7 +119,7 @@ func (ss SliceType) Bottom(n int) (top SliceType) {
 // When using slices of pointers it will only compare by address, not value.
 func (ss SliceType) Contains(lookingFor ElementType) bool {
 	for _, s := range ss {
-		if s == lookingFor {
+		if lookingFor.Equals(s) {
 			return true
 		}
 	}
@@ -149,7 +149,7 @@ func (ss SliceType) Diff(against SliceType) (added, removed SliceType) {
 			found := false
 
 			for i, element := range ss2 {
-				if element == s {
+				if s.Equals(element) {
 					ss2 = append(ss2[:i], ss2[i+1:]...)
 					found = true
 				}

--- a/type_explorer.go
+++ b/type_explorer.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+)
+
+type TypeExplorer struct {
+	TypeName string
+	Methods  []string
+}
+
+func NewTypeExplorer(pkg *ast.Package, typeName string) *TypeExplorer {
+	explorer := &TypeExplorer{
+		TypeName: typeName,
+	}
+
+	ast.Walk(explorer, pkg)
+
+	return explorer
+}
+
+func (explorer *TypeExplorer) Visit(node ast.Node) ast.Visitor {
+	if n, ok := node.(*ast.FuncDecl); ok && n.Recv != nil {
+		receiver := getIdentName(n.Recv.List[0].Type)
+		if receiver == explorer.TypeName {
+			method := fmt.Sprintf("%s(%v)", getIdentName(n.Name), getIdentName(n.Recv.List[0].Type))
+			explorer.Methods = append(explorer.Methods, method)
+		}
+	}
+
+	return explorer
+}
+
+func (explorer *TypeExplorer) HasEquals() bool {
+	lookingFor := fmt.Sprintf("Equals(%s)", explorer.TypeName)
+	for _, method := range explorer.Methods {
+		if method == lookingFor {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Some functions that compare elements, such as Contains will use the following method if it is available on the element type:

    func (a ElementType) Equals(b ElementType) bool

The `ElementType` must be the same for the receiver and argument and it must return a bool. Be careful to create the function on the pointer or non-pointer
type that is used by the slice.

Here is a minimal example:

    type Car struct {
    	Name, Color string
    }

    type Cars []*Car // ElementType is *Car

    func (c *Car) Equals(c2 *Car) bool {
    	return c.Name == c2.Name
    }

Fixes #111

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/113)
<!-- Reviewable:end -->
