### PR TITLE
Each: fix example in comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ on each elements and pass the original slice on.
 
 
 ```go
-cars.Each(func (car *Car) {
+cars.Each(func (car Car) {
     fmt.Printf("Car color is: %s\n", car.Color)
 })
 
@@ -340,7 +340,7 @@ manipulated, if you choose to do it this way, for example:
 
 ```go
 // Set all car colors to Red.
-cars.Each(func (car *Car) {
+cars.Each(func (car Car) {
     car.Color = "Red"
 })
 

--- a/functions/each.go
+++ b/functions/each.go
@@ -3,7 +3,7 @@ package functions
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       fmt.Printf("Car color is: %s\n", car.Color)
 //   })
 //
@@ -11,7 +11,7 @@ package functions
 // manipulated, if you choose to do it this way, for example:
 //
 //   // Set all car colors to Red.
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       car.Color = "Red"
 //   })
 //

--- a/pie/carpointers_pie.go
+++ b/pie/carpointers_pie.go
@@ -139,7 +139,7 @@ func (ss carPointers) DropTop(n int) (drop carPointers) {
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       fmt.Printf("Car color is: %s\n", car.Color)
 //   })
 //
@@ -147,7 +147,7 @@ func (ss carPointers) DropTop(n int) (drop carPointers) {
 // manipulated, if you choose to do it this way, for example:
 //
 //   // Set all car colors to Red.
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       car.Color = "Red"
 //   })
 //

--- a/pie/cars_pie.go
+++ b/pie/cars_pie.go
@@ -139,7 +139,7 @@ func (ss cars) DropTop(n int) (drop cars) {
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       fmt.Printf("Car color is: %s\n", car.Color)
 //   })
 //
@@ -147,7 +147,7 @@ func (ss cars) DropTop(n int) (drop cars) {
 // manipulated, if you choose to do it this way, for example:
 //
 //   // Set all car colors to Red.
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       car.Color = "Red"
 //   })
 //

--- a/pie/float64s_pie.go
+++ b/pie/float64s_pie.go
@@ -177,7 +177,7 @@ func (ss Float64s) DropTop(n int) (drop Float64s) {
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       fmt.Printf("Car color is: %s\n", car.Color)
 //   })
 //
@@ -185,7 +185,7 @@ func (ss Float64s) DropTop(n int) (drop Float64s) {
 // manipulated, if you choose to do it this way, for example:
 //
 //   // Set all car colors to Red.
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       car.Color = "Red"
 //   })
 //

--- a/pie/ints_pie.go
+++ b/pie/ints_pie.go
@@ -177,7 +177,7 @@ func (ss Ints) DropTop(n int) (drop Ints) {
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       fmt.Printf("Car color is: %s\n", car.Color)
 //   })
 //
@@ -185,7 +185,7 @@ func (ss Ints) DropTop(n int) (drop Ints) {
 // manipulated, if you choose to do it this way, for example:
 //
 //   // Set all car colors to Red.
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       car.Color = "Red"
 //   })
 //

--- a/pie/strings_pie.go
+++ b/pie/strings_pie.go
@@ -153,7 +153,7 @@ func (ss Strings) DropTop(n int) (drop Strings) {
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       fmt.Printf("Car color is: %s\n", car.Color)
 //   })
 //
@@ -161,7 +161,7 @@ func (ss Strings) DropTop(n int) (drop Strings) {
 // manipulated, if you choose to do it this way, for example:
 //
 //   // Set all car colors to Red.
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       car.Color = "Red"
 //   })
 //

--- a/template.go
+++ b/template.go
@@ -196,7 +196,7 @@ func (ss SliceType) DropTop(n int) (drop SliceType) {
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       fmt.Printf("Car color is: %s\n", car.Color)
 //   })
 //
@@ -204,7 +204,7 @@ func (ss SliceType) DropTop(n int) (drop SliceType) {
 // manipulated, if you choose to do it this way, for example:
 //
 //   // Set all car colors to Red.
-//   cars.Each(func (car *Car) {
+//   cars.Each(func (car Car) {
 //       car.Color = "Red"
 //   })
 //


### PR DESCRIPTION
Using the example 
```
	myCars.Each(func(car *Car) {
		fmt.Printf("Car color is: %s\n", car.Color)
	})
```

I get the error:
```
./main.go:31:18: cannot use func literal (type func(*Car)) as type func(Car) in argument to myCars.Each
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/157)
<!-- Reviewable:end -->
