### PR TITLE
When arrary elt type is interface, the generated code can not be build

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,20 @@ func getKeyAndElementType(pkg *ast.Package, name string, typeSpec *ast.TypeSpec)
 	if t, ok := typeSpec.Type.(*ast.ArrayType); ok {
 		explorer := NewTypeExplorer(pkg, getIdentName(t.Elt))
 
+		switch v := t.Elt.(type) {
+		case *ast.Ident:
+			if v == nil || v.Obj == nil {
+				break
+			}
+
+			if ts, ok := v.Obj.Decl.(*ast.TypeSpec); ok {
+				if _, ok := ts.Type.(*ast.InterfaceType); ok {
+					explorer.IsInterface = true
+				}
+			}
+
+		}
+
 		return pkgName, "", getIdentName(t.Elt), explorer
 	}
 
@@ -209,7 +223,7 @@ func main() {
 
 			// If its a pointer we need to replace '*' -> '&' when
 			// instantiating.
-			if elementType[0] == '*' {
+			if elementType[0] == '*' || explorer.IsInterface {
 				zeroValue = "nil"
 			}
 

--- a/type_explorer.go
+++ b/type_explorer.go
@@ -6,8 +6,9 @@ import (
 )
 
 type TypeExplorer struct {
-	TypeName string
-	Methods  []string
+	TypeName    string
+	Methods     []string
+	IsInterface bool
 }
 
 func NewTypeExplorer(pkg *ast.Package, typeName string) *TypeExplorer {


### PR DESCRIPTION
if `typeSpec` elt is interface `zeroValue` should be `nil`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/168)
<!-- Reviewable:end -->
