### PR TITLE
go generate generate.go used for first generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ same as the function. You must include documentation for your function.
 `Functions`. Make sure you choose the correct `For` value that is appropriate
 for your function.
 
-3. Run `go generate ./... && go install && go generate ./...`. The first
+3. Run `go generate generate.go && go install && go generate ./...`. The first
 `generate` is to create the pie templates, `install` will update your binary for
 the annotations and the second `generate` will use the newly created templates
 to update the generated code for the internal types. If you encounter errors


### PR DESCRIPTION
When `go generate ./...` is first used, the `pie` binary might not have been installed on the user's system while trying to generate code for the internal types, since the command will not only create the pie templates but also try to generate code for the internal types. Which will generate an error `executable file not found in $PATH`

So changing the first command to  `go generate generate.go` will only create the pie templates and then `go install` will proceed to install the binary and the third and final command  `go generate ./...` will use the newly created templates
to update the generated code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/173)
<!-- Reviewable:end -->
