### PR TITLE
added Dropwhile() and fixes issue in #173

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The letters in brackets indicate:
 | [`Contains`](#contains) (E)             | ✓      | ✓      | ✓      |      | n        | Contains returns true if the element exists in the slice.  |
 | [`Diff`](#diff) (E)                     | ✓      | ✓      | ✓      |      | n²       | Diff returns the elements that needs to be added or removed from the first slice to have the same elements in the second slice.  |
 | [`DropTop`](#droptop)                   | ✓      | ✓      | ✓      |      | n        | DropTop will return the rest slice after dropping the top n elements if the slice has less elements then n that'll return empty slice if n < 0 it'll return empty slice.  |
+| [`DropWhile`](#dropwhile)               | ✓      | ✓      | ✓      |      | n        | Drop items from the slice while f(item) is true. Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.  |
 | [`Each`](#each)                         | ✓      | ✓      | ✓      |      | n        | Each is more condensed version of Transform that allows an action to happen on each elements and pass the original slice on.  |
 | [`Equals`](#equals) (E)                 | ✓      | ✓      | ✓      |      | n        | Equals compare elements from the start to the end,  |
 | [`Extend`](#extend)                     | ✓      | ✓      | ✓      |      | n        | Extend will return a new slice with the slices of elements appended to the end.  |
@@ -323,6 +324,12 @@ many elements that exists in the largest slice.
 DropTop will return the rest slice after dropping the top n elements
 if the slice has less elements then n that'll return empty slice
 if n < 0 it'll return empty slice.
+
+
+## DropWhile
+
+Drop items from the slice while f(item) is true.
+Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.
 
 
 ## Each
@@ -795,7 +802,7 @@ same as the function. You must include documentation for your function.
 `Functions`. Make sure you choose the correct `For` value that is appropriate
 for your function.
 
-3. Run `go generate generate.go && go install && go generate ./...`. The first
+3. Run `go generate && go install && go generate ./...`. The first
 `generate` is to create the pie templates, `install` will update your binary for
 the annotations and the second `generate` will use the newly created templates
 to update the generated code for the internal types. If you encounter errors

--- a/functions/drop_while.go
+++ b/functions/drop_while.go
@@ -1,0 +1,14 @@
+package functions
+
+// Drop items from the slice while f(item) is true.
+// Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.
+func (ss SliceType) DropWhile(f func(s ElementType) bool) (ss2 SliceType) {
+	ss2 = make([]ElementType, len(ss))
+	copy(ss2, ss)
+	for i, value := range ss2 {
+		if !f(value) {
+			return ss2[i:]
+		}
+	}
+	return SliceType{}
+}

--- a/functions/main.go
+++ b/functions/main.go
@@ -32,6 +32,7 @@ var Functions = []struct {
 	{"Contains", "contains.go", ForAll, "n"},
 	{"Diff", "diff.go", ForAll, "n²"},
 	{"DropTop", "drop_top.go", ForAll, "n"},
+	{"DropWhile", "drop_while.go", ForAll, "n"},
 	{"Each", "each.go", ForAll, "n"},
 	{"Equals", "equals.go", ForAll, "n"},
 	{"Extend", "extend.go", ForAll, "n"},

--- a/pie/carpointers_pie.go
+++ b/pie/carpointers_pie.go
@@ -137,6 +137,19 @@ func (ss carPointers) DropTop(n int) (drop carPointers) {
 	return
 }
 
+// Drop items from the slice while f(item) is true.
+// Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.
+func (ss carPointers) DropWhile(f func(s *car) bool) (ss2 carPointers) {
+	ss2 = make([]*car, len(ss))
+	copy(ss2, ss)
+	for i, value := range ss2 {
+		if !f(value) {
+			return ss2[i:]
+		}
+	}
+	return carPointers{}
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/carpointers_test.go
+++ b/pie/carpointers_test.go
@@ -1086,6 +1086,42 @@ func TestCarPointers_DropTop(t *testing.T) {
 	}
 }
 
+var carPointersDropWhileTests = []struct {
+	ss        carPointers
+	f         func(s *car) bool
+	dropWhile carPointers
+}{
+	{
+		ss:        nil,
+		f:         func(s *car) bool { return s.Color == "Blue" },
+		dropWhile: carPointers{},
+	},
+	{
+		ss:        carPointers{{"Bar", "blue"}, {"Foo", "blue"}, {"Baz", "blue"}, {"Bit", "pink"}, {"Baz", "red"}},
+		f:         func(s *car) bool { return s.Color == "blue" },
+		dropWhile: carPointers{{"Bit", "pink"}, {"Baz", "red"}},
+	},
+	{
+		ss:        carPointers{{"Bar", "pink"}, {"Foo", "pink"}, {"Baz", "pink"}},
+		f:         func(s *car) bool { return s.Color == "pink" },
+		dropWhile: carPointers{},
+	},
+	{
+		ss:        carPointers{{"Bar", "blue"}, {"Bar", "blue"}, {"Bar", "yellow"}, {"Bar", "black"}, {"Bar", "blue"}},
+		f:         func(s *car) bool { return s.Color == "red" },
+		dropWhile: carPointers{{"Bar", "blue"}, {"Bar", "blue"}, {"Bar", "yellow"}, {"Bar", "black"}, {"Bar", "blue"}},
+	},
+}
+
+func TestCarPointers_DropWhile(t *testing.T) {
+	for _, test := range carPointersDropWhileTests {
+		t.Run("", func(t *testing.T) {
+			defer assertImmutableCarPointers(t, &test.ss)()
+			assert.Equal(t, test.dropWhile, test.ss.DropWhile(test.f))
+		})
+	}
+}
+
 var carPointersSubSliceTests = []struct {
 	ss       carPointers
 	start    int

--- a/pie/cars_pie.go
+++ b/pie/cars_pie.go
@@ -137,6 +137,19 @@ func (ss cars) DropTop(n int) (drop cars) {
 	return
 }
 
+// Drop items from the slice while f(item) is true.
+// Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.
+func (ss cars) DropWhile(f func(s car) bool) (ss2 cars) {
+	ss2 = make([]car, len(ss))
+	copy(ss2, ss)
+	for i, value := range ss2 {
+		if !f(value) {
+			return ss2[i:]
+		}
+	}
+	return cars{}
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/cars_test.go
+++ b/pie/cars_test.go
@@ -1061,6 +1061,42 @@ func TestCars_DropTop(t *testing.T) {
 	}
 }
 
+var carsDropWhileTests = []struct {
+	ss        cars
+	f         func(s car) bool
+	dropWhile cars
+}{
+	{
+		ss:        nil,
+		f:         func(s car) bool { return s.Color == "Blue" },
+		dropWhile: cars{},
+	},
+	{
+		ss:        cars{{"Bar", "blue"}, {"Foo", "blue"}, {"Baz", "blue"}, {"Bit", "pink"}, {"Baz", "red"}},
+		f:         func(s car) bool { return s.Color == "blue" },
+		dropWhile: cars{{"Bit", "pink"}, {"Baz", "red"}},
+	},
+	{
+		ss:        cars{{"Bar", "pink"}, {"Foo", "pink"}, {"Baz", "pink"}},
+		f:         func(s car) bool { return s.Color == "pink" },
+		dropWhile: cars{},
+	},
+	{
+		ss:        cars{{"Bar", "blue"}, {"Bar", "blue"}, {"Bar", "yellow"}, {"Bar", "black"}, {"Bar", "blue"}},
+		f:         func(s car) bool { return s.Color == "red" },
+		dropWhile: cars{{"Bar", "blue"}, {"Bar", "blue"}, {"Bar", "yellow"}, {"Bar", "black"}, {"Bar", "blue"}},
+	},
+}
+
+func TestCars_DropWhile(t *testing.T) {
+	for _, test := range carsDropWhileTests {
+		t.Run("", func(t *testing.T) {
+			defer assertImmutableCars(t, &test.ss)()
+			assert.Equal(t, test.dropWhile, test.ss.DropWhile(test.f))
+		})
+	}
+}
+
 var carsSubSliceTests = []struct {
 	ss       cars
 	start    int

--- a/pie/float64s_pie.go
+++ b/pie/float64s_pie.go
@@ -176,6 +176,19 @@ func (ss Float64s) DropTop(n int) (drop Float64s) {
 	return
 }
 
+// Drop items from the slice while f(item) is true.
+// Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.
+func (ss Float64s) DropWhile(f func(s float64) bool) (ss2 Float64s) {
+	ss2 = make([]float64, len(ss))
+	copy(ss2, ss)
+	for i, value := range ss2 {
+		if !f(value) {
+			return ss2[i:]
+		}
+	}
+	return Float64s{}
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/float64s_test.go
+++ b/pie/float64s_test.go
@@ -1233,6 +1233,43 @@ func TestFloat64s_DropTop(t *testing.T) {
 	}
 }
 
+var float64sDropWhileTests = []struct {
+	ss        Float64s
+	f         func(s float64) bool
+	dropWhile Float64s
+}{
+	{
+		ss:        nil,
+		f:         func(s float64) bool { return s == 0.1 },
+		dropWhile: Float64s{},
+	},
+	{
+		ss:        Float64s{2.1, 2.1, 2.1, 7.2, 8.1},
+		f:         func(s float64) bool { return s == 2.1 },
+		dropWhile: Float64s{7.2, 8.1},
+	},
+	{
+		ss:        Float64s{2.1, 4.1, 5.1, 7.2, 8.1},
+		f:         func(s float64) bool { return s == 0.2 },
+		dropWhile: Float64s{2.1, 4.1, 5.1, 7.2, 8.1},
+	},
+	{
+		ss:        Float64s{2.1, 2.1, 2.1, 2.1, 2.1},
+		f:         func(s float64) bool { return s == 2.1 },
+		dropWhile: Float64s{},
+	},
+}
+
+func TestFloat64s_DropWhile(t *testing.T) {
+	for _, test := range float64sDropWhileTests {
+		t.Run("", func(t *testing.T) {
+			defer assertImmutableFloat64s(t, &test.ss)()
+			fmt.Println(test.ss.DropWhile(test.f))
+			assert.Equal(t, test.dropWhile, test.ss.DropWhile(test.f))
+		})
+	}
+}
+
 var float64sSubSliceTests = []struct {
 	ss       Float64s
 	start    int

--- a/pie/ints_pie.go
+++ b/pie/ints_pie.go
@@ -176,6 +176,19 @@ func (ss Ints) DropTop(n int) (drop Ints) {
 	return
 }
 
+// Drop items from the slice while f(item) is true.
+// Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.
+func (ss Ints) DropWhile(f func(s int) bool) (ss2 Ints) {
+	ss2 = make([]int, len(ss))
+	copy(ss2, ss)
+	for i, value := range ss2 {
+		if !f(value) {
+			return ss2[i:]
+		}
+	}
+	return Ints{}
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/ints_test.go
+++ b/pie/ints_test.go
@@ -1217,6 +1217,52 @@ func TestInts_DropTop(t *testing.T) {
 	}
 }
 
+var intsDropWhileTests = []struct {
+	ss        Ints
+	f         func(s int) bool
+	dropWhile Ints
+}{
+	{
+		ss:        nil,
+		f:         func(s int) bool { return s%2 == 0 },
+		dropWhile: Ints{},
+	},
+	{
+		ss:        Ints{2, 4, 5, 7, 8},
+		f:         func(s int) bool { return s%2 == 0 },
+		dropWhile: Ints{5, 7, 8},
+	},
+	{
+		ss:        Ints{1, 3, 5, 7, 8, 10, 12, 14},
+		f:         func(s int) bool { return s%2 == 1 },
+		dropWhile: Ints{8, 10, 12, 14},
+	},
+	{
+		ss:        Ints{2, 4, 8, 16, 32, 33},
+		f:         func(s int) bool { return s > 0 && (s&(s-1)) == 0 },
+		dropWhile: Ints{33},
+	},
+	{
+		ss:        Ints{2, 4, 8, 16, 32},
+		f:         func(s int) bool { return s > 0 && (s&(s-1)) == 0 },
+		dropWhile: Ints{},
+	},
+	{
+		ss:        Ints{2, 4, 8, 16, 32},
+		f:         func(s int) bool { return false },
+		dropWhile: Ints{2, 4, 8, 16, 32},
+	},
+}
+
+func TestInts_DropWhile(t *testing.T) {
+	for _, test := range intsDropWhileTests {
+		t.Run("", func(t *testing.T) {
+			defer assertImmutableInts(t, &test.ss)()
+			assert.Equal(t, test.dropWhile, test.ss.DropWhile(test.f))
+		})
+	}
+}
+
 var intsSubSliceTests = []struct {
 	ss       Ints
 	start    int

--- a/pie/strings_pie.go
+++ b/pie/strings_pie.go
@@ -151,6 +151,19 @@ func (ss Strings) DropTop(n int) (drop Strings) {
 	return
 }
 
+// Drop items from the slice while f(item) is true.
+// Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.
+func (ss Strings) DropWhile(f func(s string) bool) (ss2 Strings) {
+	ss2 = make([]string, len(ss))
+	copy(ss2, ss)
+	for i, value := range ss2 {
+		if !f(value) {
+			return ss2[i:]
+		}
+	}
+	return Strings{}
+}
+
 // Each is more condensed version of Transform that allows an action to happen
 // on each elements and pass the original slice on.
 //

--- a/pie/strings_test.go
+++ b/pie/strings_test.go
@@ -1227,6 +1227,42 @@ func TestStrings_DropTop(t *testing.T) {
 	}
 }
 
+var stringsDropWhileTests = []struct {
+	ss        Strings
+	f         func(s string) bool
+	dropWhile Strings
+}{
+	{
+		ss:        nil,
+		f:         func(s string) bool { return s == "foo" },
+		dropWhile: Strings{},
+	},
+	{
+		ss:        Strings{"foo", "foo", "bar", "baz"},
+		f:         func(s string) bool { return s == "foo" },
+		dropWhile: Strings{"bar", "baz"},
+	},
+	{
+		ss:        Strings{"foo", "bar", "baz"},
+		f:         func(s string) bool { return s == "baz" },
+		dropWhile: Strings{"foo", "bar", "baz"},
+	},
+	{
+		ss:        Strings{"baz", "bar", "ban"},
+		f:         func(s string) bool { return strings.Contains(s, "a") },
+		dropWhile: Strings{},
+	},
+}
+
+func TestStrings_DropWhile(t *testing.T) {
+	for _, test := range stringsDropWhileTests {
+		t.Run("", func(t *testing.T) {
+			defer assertImmutableStrings(t, &test.ss)()
+			assert.Equal(t, test.dropWhile, test.ss.DropWhile(test.f))
+		})
+	}
+}
+
 // Make sure that input and output of DropTop don't share the same memory.
 func TestDropTopNonDestructive(t *testing.T) {
 	abc := Strings{"A", "B", "C"}

--- a/template.go
+++ b/template.go
@@ -192,6 +192,21 @@ func (ss SliceType) DropTop(n int) (drop SliceType) {
 	return
 }
 `,
+	"DropWhile": `package functions
+
+// Drop items from the slice while f(item) is true.
+// Afterwards, return every element until the slice is empty. It follows the same logic as the dropwhile() function from itertools in Python.
+func (ss SliceType) DropWhile(f func(s ElementType) bool) (ss2 SliceType) {
+	ss2 = make([]ElementType, len(ss))
+	copy(ss2, ss)
+	for i, value := range ss2 {
+		if !f(value) {
+			return ss2[i:]
+		}
+	}
+	return SliceType{}
+}
+`,
 	"Each": `package functions
 
 // Each is more condensed version of Transform that allows an action to happen


### PR DESCRIPTION
Added `DropWhile()` function which is similar to `dropwhile()` function from itertools in Python. The `DropWhile()` function drops items from the slice while `f(item)` function returns true.

Also used `go generate` in the README since `go generate generate.go` doesn't work from #173.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/pie/174)
<!-- Reviewable:end -->
