### PR TITLE
Add Zip function

### DIFF
--- a/v2/zip.go
+++ b/v2/zip.go
@@ -7,35 +7,19 @@ type Zipped[T1, T2 any] struct {
 }
 
 // Zip will return a new slice containing pairs with elements from input slices.
-// If input slices have diffrent length, missing elements will be padded with default values.
+// If input slices have diffrent length, the output slice will be truncated to
+// the length of the smallest input slice.
 func Zip[T1, T2 any](ss1 []T1, ss2 []T2) (ss3 []Zipped[T1, T2]) {
-	var minLen, maxLen int
-	var small int8
+	var minLen int
 
 	if len(ss1) <= len(ss2) {
-		small = 1
 		minLen = len(ss1)
-		maxLen = len(ss2)
 	} else {
-		small = 2
 		minLen = len(ss2)
-		maxLen = len(ss1)
 	}
 
 	for i := 0; i < minLen; i++ {
 		ss3 = append(ss3, Zipped[T1, T2]{ss1[i], ss2[i]})
-	}
-
-	if small == 1 {
-		var t T1
-		for i := minLen; i < maxLen; i++ {
-			ss3 = append(ss3, Zipped[T1, T2]{t, ss2[i]})
-		}
-	} else {
-		var t T2
-		for i := minLen; i < maxLen; i++ {
-			ss3 = append(ss3, Zipped[T1, T2]{ss1[i], t})
-		}
 	}
 
 	return

--- a/v2/zip.go
+++ b/v2/zip.go
@@ -1,0 +1,42 @@
+package pie
+
+// A pair struct containing two zipped values.
+type Zipped[T1, T2 any] struct {
+	A T1
+	B T2
+}
+
+// Zip will return a new slice containing pairs with elements from input slices.
+// If input slices have diffrent length, missing elements will be padded with default values.
+func Zip[T1, T2 any](ss1 []T1, ss2 []T2) (ss3 []Zipped[T1, T2]) {
+	var minLen, maxLen int
+	var small int8
+
+	if len(ss1) <= len(ss2) {
+		small = 1
+		minLen = len(ss1)
+		maxLen = len(ss2)
+	} else {
+		small = 2
+		minLen = len(ss2)
+		maxLen = len(ss1)
+	}
+
+	for i := 0; i < minLen; i++ {
+		ss3 = append(ss3, Zipped[T1, T2]{ss1[i], ss2[i]})
+	}
+
+	if small == 1 {
+		var t T1
+		for i := minLen; i < maxLen; i++ {
+			ss3 = append(ss3, Zipped[T1, T2]{t, ss2[i]})
+		}
+	} else {
+		var t T2
+		for i := minLen; i < maxLen; i++ {
+			ss3 = append(ss3, Zipped[T1, T2]{ss1[i], t})
+		}
+	}
+
+	return
+}

--- a/v2/zip.go
+++ b/v2/zip.go
@@ -9,7 +9,7 @@ type Zipped[T1, T2 any] struct {
 // Zip will return a new slice containing pairs with elements from input slices.
 // If input slices have diffrent length, the output slice will be truncated to
 // the length of the smallest input slice.
-func Zip[T1, T2 any](ss1 []T1, ss2 []T2) (ss3 []Zipped[T1, T2]) {
+func Zip[T1, T2 any](ss1 []T1, ss2 []T2) []Zipped[T1, T2] {
 	var minLen int
 
 	if len(ss1) <= len(ss2) {
@@ -18,9 +18,10 @@ func Zip[T1, T2 any](ss1 []T1, ss2 []T2) (ss3 []Zipped[T1, T2]) {
 		minLen = len(ss2)
 	}
 
+	ss3 := []Zipped[T1, T2]{}
 	for i := 0; i < minLen; i++ {
 		ss3 = append(ss3, Zipped[T1, T2]{ss1[i], ss2[i]})
 	}
 
-	return
+	return ss3
 }

--- a/v2/zip_longest.go
+++ b/v2/zip_longest.go
@@ -1,0 +1,36 @@
+package pie
+
+// ZipLongest will return a new slice containing pairs with elements from input slices.
+// If input slices have diffrent length, missing elements will be padded with default values.
+func ZipLongest[T1, T2 any](ss1 []T1, ss2 []T2) (ss3 []Zipped[T1, T2]) {
+	var minLen, maxLen int
+	var small int8
+
+	if len(ss1) <= len(ss2) {
+		small = 1
+		minLen = len(ss1)
+		maxLen = len(ss2)
+	} else {
+		small = 2
+		minLen = len(ss2)
+		maxLen = len(ss1)
+	}
+
+	for i := 0; i < minLen; i++ {
+		ss3 = append(ss3, Zipped[T1, T2]{ss1[i], ss2[i]})
+	}
+
+	if small == 1 {
+		var t T1
+		for i := minLen; i < maxLen; i++ {
+			ss3 = append(ss3, Zipped[T1, T2]{t, ss2[i]})
+		}
+	} else {
+		var t T2
+		for i := minLen; i < maxLen; i++ {
+			ss3 = append(ss3, Zipped[T1, T2]{ss1[i], t})
+		}
+	}
+
+	return
+}

--- a/v2/zip_longest.go
+++ b/v2/zip_longest.go
@@ -2,7 +2,7 @@ package pie
 
 // ZipLongest will return a new slice containing pairs with elements from input slices.
 // If input slices have diffrent length, missing elements will be padded with default values.
-func ZipLongest[T1, T2 any](ss1 []T1, ss2 []T2) (ss3 []Zipped[T1, T2]) {
+func ZipLongest[T1, T2 any](ss1 []T1, ss2 []T2) []Zipped[T1, T2] {
 	var minLen, maxLen int
 	var small int8
 
@@ -16,6 +16,7 @@ func ZipLongest[T1, T2 any](ss1 []T1, ss2 []T2) (ss3 []Zipped[T1, T2]) {
 		maxLen = len(ss1)
 	}
 
+	ss3 := []Zipped[T1, T2]{}
 	for i := 0; i < minLen; i++ {
 		ss3 = append(ss3, Zipped[T1, T2]{ss1[i], ss2[i]})
 	}
@@ -32,5 +33,5 @@ func ZipLongest[T1, T2 any](ss1 []T1, ss2 []T2) (ss3 []Zipped[T1, T2]) {
 		}
 	}
 
-	return
+	return ss3
 }

--- a/v2/zip_longest_test.go
+++ b/v2/zip_longest_test.go
@@ -10,20 +10,9 @@ func TestZipLongest(t *testing.T) {
 	for _, test := range zipTests {
 
 		t.Run("", func(t *testing.T) {
-			for i, pair := range pie.ZipLongest(test.ss1, test.ss2) {
-				var a int
-				var b float32
+			c := pie.ZipLongest(test.ss1, test.ss2)
 
-				if i < len(test.ss1) {
-					a = test.ss1[i]
-				}
-				if i < len(test.ss2) {
-					b = test.ss2[i]
-				}
-
-				assert.Equal(t, pair.A, a)
-				assert.Equal(t, pair.B, b)
-			}
+			assert.Equal(t, c, test.expectedLong)
 		})
 	}
 }

--- a/v2/zip_longest_test.go
+++ b/v2/zip_longest_test.go
@@ -1,0 +1,29 @@
+package pie_test
+
+import (
+	"github.com/elliotchance/pie/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestZipLongest(t *testing.T) {
+	for _, test := range zipTests {
+
+		t.Run("", func(t *testing.T) {
+			for i, pair := range pie.ZipLongest(test.Ss1, test.Ss2) {
+				var a int
+				var b float32
+
+				if i < len(test.Ss1) {
+					a = test.Ss1[i]
+				}
+				if i < len(test.Ss2) {
+					b = test.Ss2[i]
+				}
+
+				assert.Equal(t, pair.A, a)
+				assert.Equal(t, pair.B, b)
+			}
+		})
+	}
+}

--- a/v2/zip_longest_test.go
+++ b/v2/zip_longest_test.go
@@ -10,15 +10,15 @@ func TestZipLongest(t *testing.T) {
 	for _, test := range zipTests {
 
 		t.Run("", func(t *testing.T) {
-			for i, pair := range pie.ZipLongest(test.Ss1, test.Ss2) {
+			for i, pair := range pie.ZipLongest(test.ss1, test.ss2) {
 				var a int
 				var b float32
 
-				if i < len(test.Ss1) {
-					a = test.Ss1[i]
+				if i < len(test.ss1) {
+					a = test.ss1[i]
 				}
-				if i < len(test.Ss2) {
-					b = test.Ss2[i]
+				if i < len(test.ss2) {
+					b = test.ss2[i]
 				}
 
 				assert.Equal(t, pair.A, a)

--- a/v2/zip_test.go
+++ b/v2/zip_test.go
@@ -7,35 +7,46 @@ import (
 )
 
 var zipTests = []struct {
-	Ss1 []int
-	Ss2 []float32
+	ss1           []int
+	ss2           []float32
+	expectedShort []pie.Zipped[int, float32]
+	expectedLong  []pie.Zipped[int, float32]
 }{
 	{
 		[]int{},
 		[]float32{},
+		[]pie.Zipped[int, float32]{},
+		[]pie.Zipped[int, float32]{},
 	},
 	{
 		[]int{1, 2, 3, 4, 5},
 		[]float32{},
+		[]pie.Zipped[int, float32]{},
+		[]pie.Zipped[int, float32]{{1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}},
 	},
 	{
 		[]int{},
 		[]float32{1.0, 2.0, 3.0, 4.0, 5.0},
+		[]pie.Zipped[int, float32]{},
+		[]pie.Zipped[int, float32]{{0, 1.0}, {0, 2.0}, {0, 3.0}, {0, 4.0}, {0, 5.0}},
 	},
-	// the same length
 	{
 		[]int{1, 2, 3, 4, 5},
 		[]float32{1.0, 2.0, 3.0, 4.0, 5.0},
+		[]pie.Zipped[int, float32]{{1, 1.0}, {2, 2.0}, {3, 3.0}, {4, 4.0}, {5, 5.0}},
+		[]pie.Zipped[int, float32]{{1, 1.0}, {2, 2.0}, {3, 3.0}, {4, 4.0}, {5, 5.0}},
 	},
-	// Ss1 bigger
 	{
 		[]int{1, 2, 3, 4, 5, 6, 7, 8},
 		[]float32{1.0, 2.0, 3.0, 4.0, 5.0},
+		[]pie.Zipped[int, float32]{{1, 1.0}, {2, 2.0}, {3, 3.0}, {4, 4.0}, {5, 5.0}},
+		[]pie.Zipped[int, float32]{{1, 1.0}, {2, 2.0}, {3, 3.0}, {4, 4.0}, {5, 5.0}, {6, 0}, {7, 0}, {8, 0}},
 	},
-	// Ss1 less
 	{
 		[]int{1, 2, 3},
 		[]float32{1.0, 2.0, 3.0, 4.0, 5.0},
+		[]pie.Zipped[int, float32]{{1, 1.0}, {2, 2.0}, {3, 3.0}},
+		[]pie.Zipped[int, float32]{{1, 1.0}, {2, 2.0}, {3, 3.0}, {0, 4.0}, {0, 5.0}},
 	},
 }
 
@@ -43,20 +54,9 @@ func TestZip(t *testing.T) {
 	for _, test := range zipTests {
 
 		t.Run("", func(t *testing.T) {
-			for i, pair := range pie.Zip(test.Ss1, test.Ss2) {
-				var a int
-				var b float32
+			c := pie.Zip(test.ss1, test.ss2)
 
-				if i < len(test.Ss1) {
-					a = test.Ss1[i]
-				}
-				if i < len(test.Ss2) {
-					b = test.Ss2[i]
-				}
-
-				assert.Equal(t, pair.A, a)
-				assert.Equal(t, pair.B, b)
-			}
+			assert.Equal(t, c, test.expectedShort)
 		})
 	}
 }

--- a/v2/zip_test.go
+++ b/v2/zip_test.go
@@ -40,7 +40,6 @@ var zipTests = []struct {
 }
 
 func TestZip(t *testing.T) {
-
 	for _, test := range zipTests {
 
 		t.Run("", func(t *testing.T) {

--- a/v2/zip_test.go
+++ b/v2/zip_test.go
@@ -1,0 +1,63 @@
+package pie_test
+
+import (
+	"github.com/elliotchance/pie/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var zipTests = []struct {
+	Ss1 []int
+	Ss2 []float32
+}{
+	{
+		[]int{},
+		[]float32{},
+	},
+	{
+		[]int{1, 2, 3, 4, 5},
+		[]float32{},
+	},
+	{
+		[]int{},
+		[]float32{1.0, 2.0, 3.0, 4.0, 5.0},
+	},
+	// the same length
+	{
+		[]int{1, 2, 3, 4, 5},
+		[]float32{1.0, 2.0, 3.0, 4.0, 5.0},
+	},
+	// Ss1 bigger
+	{
+		[]int{1, 2, 3, 4, 5, 6, 7, 8},
+		[]float32{1.0, 2.0, 3.0, 4.0, 5.0},
+	},
+	// Ss1 less
+	{
+		[]int{1, 2, 3},
+		[]float32{1.0, 2.0, 3.0, 4.0, 5.0},
+	},
+}
+
+func TestZip(t *testing.T) {
+
+	for _, test := range zipTests {
+
+		t.Run("", func(t *testing.T) {
+			for i, pair := range pie.Zip(test.Ss1, test.Ss2) {
+				var a int
+				var b float32
+
+				if i < len(test.Ss1) {
+					a = test.Ss1[i]
+				}
+				if i < len(test.Ss2) {
+					b = test.Ss2[i]
+				}
+
+				assert.Equal(t, pair.A, a)
+				assert.Equal(t, pair.B, b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With `Zip` and `ZipLongest` function we can do:
```go
a := []int{1, 2, 3, 4, 5}
b := []float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6}

for _, p := range pie.Zip(a, b) {
    fmt.Println(p)
}
for _, p := range pie.ZipLongest(a, b) {
    fmt.Println(p)
}
// {1 1.1}
// {2 2.2}
// {3 3.3}
// {4 4.4}
// {5 5.5}
// {0 6.6} <- 0 is default value not in original slice
```

It is the same as `zip()` and `itertools.zip_longest` in Python

```Python
a = [1, 2, 3, 4, 5]
b = [1.1, 2.2, 3.3, 4.4, 5.5, 6.6]

for p in zip(a, b):
    print(p)
```

```Python
a = [1, 2, 3, 4, 5]
b = [1.1, 2.2, 3.3, 4.4, 5.5, 6.6]

for p in itertools.zip_longest(a, b, fillvalue=0):
    print(p)
```