### PR TITLE
feat: add omit and pick

### DIFF
--- a/v2/omit.go
+++ b/v2/omit.go
@@ -1,0 +1,30 @@
+package pie
+
+// Omit returns a new map without the given keys.
+func Omit[K comparable, V any](keys []K, m map[K]V) map[K]V {
+	keysLength := len(keys)
+	mapLength := len(m)
+
+	if keysLength == 0 || mapLength == 0 {
+		return m
+	}
+
+	result := make(map[K]V, len(keys))
+
+	for key, value := range m {
+		if !containsKey(keys, key) {
+			result[key] = value
+		}
+	}
+
+	return result
+}
+
+func containsKey[K comparable](keys []K, key K) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/omit_test.go
+++ b/v2/omit_test.go
@@ -1,0 +1,34 @@
+package pie_test
+
+import (
+	"github.com/elliotchance/pie/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOmit(t *testing.T) {
+	assert.Equal(t,
+		map[string]int{"b": 2},
+		pie.Omit([]string{"a"}, map[string]int{"a": 1, "b": 2}),
+	)
+
+	assert.Equal(t,
+		map[int]string{1: "one", 3: "three"},
+		pie.Omit([]int{2}, map[int]string{1: "one", 2: "two", 3: "three"}),
+	)
+
+	assert.Equal(t,
+		map[string]string{},
+		pie.Omit([]string{"x", "y", "z"}, map[string]string{}),
+	)
+
+	assert.Equal(t,
+		map[string]int{"a": 1, "b": 2, "c": 3},
+		pie.Omit([]string{}, map[string]int{"a": 1, "b": 2, "c": 3}),
+	)
+
+	assert.Equal(t,
+		map[string]int{"a": 1, "b": 2, "c": 3},
+		pie.Omit([]string{"x", "y", "z"}, map[string]int{"a": 1, "b": 2, "c": 3}),
+	)
+}

--- a/v2/pick.go
+++ b/v2/pick.go
@@ -1,0 +1,21 @@
+package pie
+
+// Pick returns a new map with the given keys.
+func Pick[K comparable, V any](keys []K, m map[K]V) map[K]V {
+	keysLength := len(keys)
+	mapLength := len(m)
+
+	if keysLength == 0 || mapLength == 0 {
+		return make(map[K]V, 0)
+	}
+
+	result := make(map[K]V, len(keys))
+
+	for _, key := range keys {
+		if value, ok := m[key]; ok {
+			result[key] = value
+		}
+	}
+
+	return result
+}

--- a/v2/pick_test.go
+++ b/v2/pick_test.go
@@ -1,0 +1,34 @@
+package pie_test
+
+import (
+	"github.com/elliotchance/pie/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPick(t *testing.T) {
+	assert.Equal(t,
+		map[string]string{"a": "1", "c": "3"},
+		pie.Pick([]string{"a", "c"}, map[string]string{"a": "1", "b": "2", "c": "3"}),
+	)
+
+	assert.Equal(t,
+		map[int]string{2: "two", 3: "three"},
+		pie.Pick([]int{2, 3}, map[int]string{1: "one", 2: "two", 3: "three"}),
+	)
+
+	assert.Equal(t,
+		map[string]string{},
+		pie.Pick([]string{"x", "y", "z"}, map[string]string{}),
+	)
+
+	assert.Equal(t,
+		map[string]int{},
+		pie.Pick([]string{}, map[string]int{"a": 1, "b": 2, "c": 3}),
+	)
+
+	assert.Equal(t,
+		map[string]int{},
+		pie.Pick([]string{"x", "y", "z"}, map[string]int{"a": 1, "b": 2, "c": 3}),
+	)
+}


### PR DESCRIPTION
- Pick function:
Adds Pick function, which generates a new map containing the specified keys. Any keys that do not exist in the original map are ignored.
- Omit Function:
Adds Omit function, designed to produce a new map that excludes the specified keys. Similar to Pick, any non-existent keys in the original map are ignored.